### PR TITLE
Fix inconsistent setup ids

### DIFF
--- a/src/main/java/bdv/util/BdvHandleFrame.java
+++ b/src/main/java/bdv/util/BdvHandleFrame.java
@@ -2,6 +2,7 @@ package bdv.util;
 
 import java.awt.event.WindowEvent;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.scijava.ui.behaviour.io.InputTriggerConfig;
@@ -32,8 +33,9 @@ public class BdvHandleFrame extends BdvHandle
 	{
 		super( options );
 		frameTitle = options.values.getFrameTitle();
-		bdv = null;
 		cacheControls = new CacheControls();
+
+		createViewer( Collections.emptyList(), Collections.emptyList(), 1 );
 	}
 
 	public BigDataViewer getBigDataViewer()


### PR DESCRIPTION
@hanslovsky and I identified a bug that causes inconsistent order of setup ids using `BdvFunctions.show()` methods. When the first source is added, the viewer is not created yet, and `BdvHandleFrame.add()` creates it internally. But `BdvHandleFrame.getUnusedSetupId()` is called before that, and it uses `setupAssignments` object (which is `null` in the described case) to look up the max used id. It will store the new mapping `null->1`.
If we save a _bdv-settings.xml_ file, it will contain a description of the source with `id=1`.

The problem occurs when we want to display a source in another BDV window. The logic will be the same as above, but this time it will assign `id=2` to the new source because of the existing `null` mapping. It will update the mapping with `null->2`.
If we try to load the existing _bdv-settings.xml_ file, it will throw an exception because the setup id is different. The expected behavior is that the setup ids are consistent across runs.

We came up with a solution to force creating the viewer before adding any sources, so that `setupAssignments` is never `null`.