### PR TITLE
Relax NumericType restriction on AbstractSource and RandomAccessibleSources

### DIFF
--- a/src/main/java/bdv/util/DefaultInterpolators.java
+++ b/src/main/java/bdv/util/DefaultInterpolators.java
@@ -1,7 +1,5 @@
 package bdv.util;
 
-import java.util.function.Function;
-
 import bdv.viewer.Interpolation;
 import net.imglib2.RandomAccessible;
 import net.imglib2.interpolation.InterpolatorFactory;
@@ -9,7 +7,7 @@ import net.imglib2.interpolation.randomaccess.ClampingNLinearInterpolatorFactory
 import net.imglib2.interpolation.randomaccess.NearestNeighborInterpolatorFactory;
 import net.imglib2.type.numeric.NumericType;
 
-public class DefaultInterpolators< T extends NumericType< T > > implements Function< Interpolation, InterpolatorFactory< T, RandomAccessible< T > > >
+public class DefaultInterpolators< T extends NumericType< T > > implements InterpolationFunction< T >
 {
 	private final InterpolatorFactory< T, RandomAccessible< T > >[] factories;
 
@@ -21,6 +19,7 @@ public class DefaultInterpolators< T extends NumericType< T > > implements Funct
 		factories[ Interpolation.NLINEAR.ordinal() ] = new ClampingNLinearInterpolatorFactory<>();
 	}
 
+	@Override
 	public InterpolatorFactory< T, RandomAccessible< T > > get( final Interpolation method )
 	{
 		return factories[ method.ordinal() ];
@@ -29,11 +28,5 @@ public class DefaultInterpolators< T extends NumericType< T > > implements Funct
 	public int size()
 	{
 		return factories.length;
-	}
-
-	@Override
-	public InterpolatorFactory< T, RandomAccessible< T > > apply( final Interpolation t )
-	{
-		return get( t );
 	}
 }

--- a/src/main/java/bdv/util/InterpolationFunction.java
+++ b/src/main/java/bdv/util/InterpolationFunction.java
@@ -1,0 +1,19 @@
+package bdv.util;
+
+import java.util.function.Function;
+
+import bdv.viewer.Interpolation;
+import net.imglib2.RandomAccessible;
+import net.imglib2.interpolation.InterpolatorFactory;
+import net.imglib2.type.Type;
+
+public interface InterpolationFunction< T extends Type< T > > extends Function< Interpolation, InterpolatorFactory< T, RandomAccessible< T > > >
+{
+	public abstract InterpolatorFactory< T, RandomAccessible< T > > get( final Interpolation method );
+	
+	@Override
+	public default InterpolatorFactory< T, RandomAccessible< T > > apply( final Interpolation t )
+	{
+		return get( t );
+	}
+}

--- a/src/main/java/bdv/util/RandomAccessibleIntervalSource.java
+++ b/src/main/java/bdv/util/RandomAccessibleIntervalSource.java
@@ -32,10 +32,10 @@ import bdv.viewer.Interpolation;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.RealRandomAccessible;
 import net.imglib2.realtransform.AffineTransform3D;
-import net.imglib2.type.numeric.NumericType;
+import net.imglib2.type.Type;
 import net.imglib2.view.Views;
 
-public class RandomAccessibleIntervalSource< T extends NumericType< T > > extends AbstractSource< T >
+public class RandomAccessibleIntervalSource< T extends Type< T > > extends AbstractSource< T >
 {
 	private final RandomAccessibleInterval< T > source;
 
@@ -61,10 +61,8 @@ public class RandomAccessibleIntervalSource< T extends NumericType< T > > extend
 		this.source = img;
 		this.sourceTransform = sourceTransform;
 		interpolatedSources = new RealRandomAccessible[ Interpolation.values().length ];
-		final T zero = getType().createVariable();
-		zero.setZero();
 		for ( final Interpolation method : Interpolation.values() )
-			interpolatedSources[ method.ordinal() ] = Views.interpolate( Views.extendValue( source, zero ), interpolators.get( method ) );
+			interpolatedSources[ method.ordinal() ] = Views.interpolate( Views.extendValue( source, extension.copy() ), interpolators.get( method ) );
 	}
 
 	@Override

--- a/src/main/java/bdv/util/RandomAccessibleIntervalSource4D.java
+++ b/src/main/java/bdv/util/RandomAccessibleIntervalSource4D.java
@@ -34,10 +34,10 @@ import bdv.viewer.Interpolation;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.RealRandomAccessible;
 import net.imglib2.realtransform.AffineTransform3D;
-import net.imglib2.type.numeric.NumericType;
+import net.imglib2.type.Type;
 import net.imglib2.view.Views;
 
-public class RandomAccessibleIntervalSource4D< T extends NumericType< T > > extends AbstractSource< T >
+public class RandomAccessibleIntervalSource4D< T extends Type< T > > extends AbstractSource< T >
 {
 	private final RandomAccessibleInterval< T > source;
 
@@ -75,11 +75,9 @@ public class RandomAccessibleIntervalSource4D< T extends NumericType< T > > exte
 		currentTimePointIndex = timepointIndex;
 		if ( isPresent( timepointIndex ) )
 		{
-			final T zero = getType().createVariable();
-			zero.setZero();
 			currentSource = Views.hyperSlice( source, 3, timepointIndex );
 			for ( final Interpolation method : Interpolation.values() )
-				currentInterpolatedSources[ method.ordinal() ] = Views.interpolate( Views.extendValue( currentSource, zero ), interpolators.get( method ) );
+				currentInterpolatedSources[ method.ordinal() ] = Views.interpolate( Views.extendValue( currentSource, extension.copy() ), interpolators.get( method ) );
 		}
 		else
 		{

--- a/src/main/java/bdv/util/RandomAccessibleSource.java
+++ b/src/main/java/bdv/util/RandomAccessibleSource.java
@@ -34,10 +34,10 @@ import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.RealRandomAccessible;
 import net.imglib2.realtransform.AffineTransform3D;
-import net.imglib2.type.numeric.NumericType;
+import net.imglib2.type.Type;
 import net.imglib2.view.Views;
 
-public class RandomAccessibleSource< T extends NumericType< T > > extends AbstractSource< T >
+public class RandomAccessibleSource< T extends Type< T > > extends AbstractSource< T >
 {
 	private final RandomAccessible< T > source;
 

--- a/src/main/java/bdv/util/RandomAccessibleSource4D.java
+++ b/src/main/java/bdv/util/RandomAccessibleSource4D.java
@@ -36,11 +36,11 @@ import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.RealRandomAccessible;
 import net.imglib2.realtransform.AffineTransform3D;
-import net.imglib2.type.numeric.NumericType;
+import net.imglib2.type.Type;
 import net.imglib2.util.Intervals;
 import net.imglib2.view.Views;
 
-public class RandomAccessibleSource4D< T extends NumericType< T > > extends AbstractSource< T >
+public class RandomAccessibleSource4D< T extends Type< T > > extends AbstractSource< T >
 {
 	private final RandomAccessible< T > source;
 
@@ -88,8 +88,6 @@ public class RandomAccessibleSource4D< T extends NumericType< T > > extends Abst
 		currentTimePointIndex = timepointIndex;
 		if ( isPresent( timepointIndex ) )
 		{
-			final T zero = getType().createVariable();
-			zero.setZero();
 			final RandomAccessible< T > slice = Views.hyperSlice( source, 3, timepointIndex );
 			currentSource = Views.interval( slice, timeSliceInterval );
 			for ( final Interpolation method : Interpolation.values() )


### PR DESCRIPTION
While not immediately applicable to `BdvFunctions.show()`, relaxing the `NumericType` constraint on  `AbstractSource` and the `RandomAccessibleSource` classes would be helpful for something like `ViewerPanel.addSource()`, allowing these convenience classes to be used in those applications as well (i.e. passing a `RandomAccessibleInterval<LabelMultisetType>`).

In the case where `T` is not a `NumericType`, only the `NearestNeighborInterpolator` is used, rather than `DefaultInterpolators` which requires `NumericType` so that it can use both Nearest Neighbor and NLinear.

Notably, [this solution uses a raw type](https://github.com/shrucis1/bigdataviewer-vistools/blob/cba1535a4f34d4757ab53eed74375eb31354c134/src/main/java/bdv/util/AbstractSource.java#L55) on `DefaultInterpolators`, but I don't know of a much better way to do it.

@hanslovsky suggested this change.