### PR TITLE
Add missing long type

### DIFF
--- a/src/main/java/bdv/util/volatiles/VolatileTypeMatcher.java
+++ b/src/main/java/bdv/util/volatiles/VolatileTypeMatcher.java
@@ -4,6 +4,7 @@ import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.ARGBType;
 import net.imglib2.type.numeric.integer.ByteType;
 import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.type.numeric.integer.LongType;
 import net.imglib2.type.numeric.integer.ShortType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
 import net.imglib2.type.numeric.integer.UnsignedIntType;
@@ -16,6 +17,7 @@ import net.imglib2.type.volatiles.VolatileByteType;
 import net.imglib2.type.volatiles.VolatileDoubleType;
 import net.imglib2.type.volatiles.VolatileFloatType;
 import net.imglib2.type.volatiles.VolatileIntType;
+import net.imglib2.type.volatiles.VolatileLongType;
 import net.imglib2.type.volatiles.VolatileShortType;
 import net.imglib2.type.volatiles.VolatileUnsignedByteType;
 import net.imglib2.type.volatiles.VolatileUnsignedIntType;
@@ -38,6 +40,8 @@ public class VolatileTypeMatcher
 			return new VolatileShortType();
 		else if ( type instanceof IntType )
 			return new VolatileIntType();
+		else if ( type instanceof LongType )
+			return new VolatileLongType();
 		else if ( type instanceof UnsignedByteType )
 			return new VolatileUnsignedByteType();
 		else if ( type instanceof UnsignedShortType )


### PR DESCRIPTION
The VolatileTypeMatcher was not generating volatile for the long type.