### PR TITLE
Support XYCZT axis order for ImageJ1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>17.1.1</version>
+		<version>19.2.0</version>
 		<relativePath />
 	</parent>
 
@@ -91,6 +91,9 @@
 
 		<!-- NB: Deploy releases to the ImageJ Maven repository. -->
 		<releaseProfiles>deploy-to-imagej</releaseProfiles>
+		
+		<bigdataviewer-core.version>4.3.2</bigdataviewer-core.version>
+		<ui-behaviour.version>1.3.0</ui-behaviour.version>
 	</properties>
 
 	<repositories>
@@ -104,32 +107,28 @@
 		<dependency>
 			<groupId>sc.fiji</groupId>
 			<artifactId>bigdataviewer-core</artifactId>
-			<version>4.3.2</version>
+			<version>${bigdataviewer-core.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>net.imglib2</groupId>
 			<artifactId>imglib2</artifactId>
-			<version>4.2.0</version>
 		</dependency>
 		<dependency>
 			<groupId>net.imglib2</groupId>
 			<artifactId>imglib2-cache</artifactId>
-			<version>1.0.0-beta-5</version>
 		</dependency>
 		<dependency>
 			<groupId>net.imglib2</groupId>
 			<artifactId>imglib2-realtransform</artifactId>
-			<version>2.0.0-beta-36</version>
 		</dependency>
 		<dependency>
 			<groupId>net.imglib2</groupId>
 			<artifactId>imglib2-ui</artifactId>
-			<version>2.0.0-beta-32</version>
 		</dependency>
 		<dependency>
 			<groupId>org.scijava</groupId>
 			<artifactId>ui-behaviour</artifactId>
-			<version>1.3.0</version>
+			<version>${ui-behaviour.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/src/main/java/bdv/util/AxisOrder.java
+++ b/src/main/java/bdv/util/AxisOrder.java
@@ -21,6 +21,7 @@ public enum AxisOrder
 	XYZT  ( 4, -1, false, false ), // --> XYZT
 	XYZCT ( 5,  3, false, false ), // --> XYZT
 	XYZTC ( 5,  4, false, false ), // --> XYZT
+	XYCZT ( 5,  2, false, false ), // --> XYCZT
 	XY    ( 2, -1, true,  false ), // --> XY   --> XYZ
 	XYC   ( 3,  2, true,  false ), // --> XY   --> XYZ
 	XYT   ( 3, -1, true,  true ),  // --> XYT  --> XYTZ --> XYZT


### PR DESCRIPTION
Resolves #14.

To test this in Fiji, I opened the *Mitosis* sample image and used this Groovy script:

```groovy
#@ Img img

import bdv.util.AxisOrder
import bdv.util.Bdv
import bdv.util.BdvFunctions

bdv = BdvFunctions.show(img, "img", Bdv.options().axisOrder(AxisOrder.XYCZT))
```

---

I also edited `pom.xml` to use `<properties>` to override versions that are managed in `pom-scijava`, I hope that's fine.

---

On a related note: is there a reason why `AxisOrder.DEFAULT` resolves to `XYZTC` with 5 dimensions? It would be great if the ImageJ 1.x default axis order would work without additional options:


```groovy
#@ Img img

import bdv.util.BdvFunctions

bdv = BdvFunctions.show(img, "img")
```
