### PR TITLE
Add CacheControlUnsafe interface

### DIFF
--- a/src/main/java/bdv/util/volatiles/CacheControlUnsafe.java
+++ b/src/main/java/bdv/util/volatiles/CacheControlUnsafe.java
@@ -1,0 +1,27 @@
+package bdv.util.volatiles;
+
+import net.imglib2.cache.AbstractCache;
+import net.imglib2.cache.volatiles.AbstractVolatileCache;
+
+/**
+ *
+ * @author Philipp Hanslovsky
+ *
+ *         This interface is used to expose controls of
+ *         {@link AbstractVolatileCache volatile caches} and
+ *         {@link AbstractCache caches}, e.g. in {@link VolatileViewData}.
+ *         Methods in this interface may have implications and/or side-effects
+ *         and should be used with caution/by callers who are aware of these.
+ *
+ */
+public interface CacheControlUnsafe
+{
+
+	/**
+	 * Invalidate all existing cache entries, e.g.
+	 * {@link AbstractCache#invalidateAll() or
+	 * {@link AbstractVolatileCache#invalidateAll()}}.
+	 */
+	public void invalidateAll();
+
+}

--- a/src/main/java/bdv/util/volatiles/VolatileViewData.java
+++ b/src/main/java/bdv/util/volatiles/VolatileViewData.java
@@ -31,7 +31,7 @@ public class VolatileViewData< T, V extends Volatile< T > >
 
 	private final CacheControl cacheControl;
 
-	private final Runnable clearCache;
+	private final CacheControlUnsafe cacheControlUsnafe;
 
 	private final T type;
 
@@ -40,13 +40,13 @@ public class VolatileViewData< T, V extends Volatile< T > >
 	public VolatileViewData(
 			final RandomAccessible< V > img,
 			final CacheControl cacheControl,
-			final Runnable clearCache,
+			final CacheControlUnsafe cacheControlUsnafe,
 			final T type,
 			final V volatileType )
 	{
 		this.img = img;
 		this.cacheControl = cacheControl;
-		this.clearCache = clearCache;
+		this.cacheControlUsnafe = cacheControlUsnafe;
 		this.type = type;
 		this.volatileType = volatileType;
 	}
@@ -74,15 +74,15 @@ public class VolatileViewData< T, V extends Volatile< T > >
 	}
 
 	/**
-	 * Get a handle to the {@link Cache#invalidateAll()} method of the
-	 * underlying {@link Cache}.
+	 * Get the {@link CacheControlUnsafe} for the {@link CachedCellImg}(s) at the
+	 * bottom of the view cascade.
 	 *
-	 * @return a handle to the {@link Cache#invalidateAll()} method of the
-	 *         underlying {@link Cache}.
+	 * @return the {@link CacheControlUnsafe} for the {@link CachedCellImg}(s) at the
+	 *         bottom of the view cascade
 	 */
-	public Runnable getClearCache()
+	public CacheControlUnsafe getCacheControlUnsafe()
 	{
-		return this.clearCache;
+		return this.cacheControlUsnafe;
 	}
 
 	/**

--- a/src/main/java/bdv/util/volatiles/VolatileViewData.java
+++ b/src/main/java/bdv/util/volatiles/VolatileViewData.java
@@ -4,6 +4,7 @@ import bdv.cache.CacheControl;
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.Volatile;
+import net.imglib2.cache.Cache;
 import net.imglib2.cache.img.CachedCellImg;
 
 /**
@@ -22,12 +23,15 @@ import net.imglib2.cache.img.CachedCellImg;
  *            corresponding volatile pixel type
  *
  * @author Tobias Pietzsch
+ * @author Philipp Hanslovsky
  */
 public class VolatileViewData< T, V extends Volatile< T > >
 {
 	private final RandomAccessible< V > img;
 
 	private final CacheControl cacheControl;
+
+	private final Runnable clearCache;
 
 	private final T type;
 
@@ -36,11 +40,13 @@ public class VolatileViewData< T, V extends Volatile< T > >
 	public VolatileViewData(
 			final RandomAccessible< V > img,
 			final CacheControl cacheControl,
+			final Runnable clearCache,
 			final T type,
 			final V volatileType )
 	{
 		this.img = img;
 		this.cacheControl = cacheControl;
+		this.clearCache = clearCache;
 		this.type = type;
 		this.volatileType = volatileType;
 	}
@@ -65,6 +71,18 @@ public class VolatileViewData< T, V extends Volatile< T > >
 	public CacheControl getCacheControl()
 	{
 		return cacheControl;
+	}
+
+	/**
+	 * Get a handle to the {@link Cache#invalidateAll()} method of the
+	 * underlying {@link Cache}.
+	 *
+	 * @return a handle to the {@link Cache#invalidateAll()} method of the
+	 *         underlying {@link Cache}.
+	 */
+	public Runnable getClearCache()
+	{
+		return this.clearCache;
 	}
 
 	/**

--- a/src/main/java/bdv/util/volatiles/VolatileViews.java
+++ b/src/main/java/bdv/util/volatiles/VolatileViews.java
@@ -108,7 +108,7 @@ public class VolatileViews
 			return new VolatileViewData<>(
 					new IntervalView<>( sourceData.getImg(), view ),
 					sourceData.getCacheControl(),
-					sourceData.getClearCache(),
+					sourceData.getCacheControlUnsafe(),
 					sourceData.getType(),
 					sourceData.getVolatileType() );
 		}
@@ -119,7 +119,7 @@ public class VolatileViews
 			return new VolatileViewData<>(
 					new MixedTransformView<>( sourceData.getImg(), view.getTransformToSource() ),
 					sourceData.getCacheControl(),
-					sourceData.getClearCache(),
+					sourceData.getCacheControlUnsafe(),
 					sourceData.getType(),
 					sourceData.getVolatileType() );
 		}

--- a/src/main/java/bdv/util/volatiles/VolatileViews.java
+++ b/src/main/java/bdv/util/volatiles/VolatileViews.java
@@ -31,6 +31,7 @@ import net.imglib2.view.MixedTransformView;
  * BigDataViewer while loading asynchronously.
  *
  * @author Tobias Pietzsch
+ * @author Philipp Hanslovsky
  */
 public class VolatileViews
 {
@@ -107,6 +108,7 @@ public class VolatileViews
 			return new VolatileViewData<>(
 					new IntervalView<>( sourceData.getImg(), view ),
 					sourceData.getCacheControl(),
+					sourceData.getClearCache(),
 					sourceData.getType(),
 					sourceData.getVolatileType() );
 		}
@@ -117,6 +119,7 @@ public class VolatileViews
 			return new VolatileViewData<>(
 					new MixedTransformView<>( sourceData.getImg(), view.getTransformToSource() ),
 					sourceData.getCacheControl(),
+					sourceData.getClearCache(),
 					sourceData.getType(),
 					sourceData.getVolatileType() );
 		}
@@ -147,7 +150,7 @@ public class VolatileViews
 		@SuppressWarnings( "rawtypes" )
 		final VolatileCachedCellImg< V, ? > img = createVolatileCachedCellImg( grid, vtype, dirty, ( Cache ) cache, queue, hints );
 
-		return new VolatileViewData<>( img, queue, type, vtype );
+		return new VolatileViewData<>( img, queue, cache::invalidateAll, type, vtype );
 	}
 
 	private static < T extends NativeType< T >, A extends VolatileArrayDataAccess< A > > VolatileCachedCellImg< T, A > createVolatileCachedCellImg(


### PR DESCRIPTION
Exposes controls for (Volatile-)Cache that should be handled with care.

Currently, this is only `AbstractVolatileCache.invalidateAll()/AbstractCache.invalidateAll()` 