### PR TITLE
Make version of BdvFunctions.show( Source ) with numTimePoints argument

### DIFF
--- a/src/main/java/bdv/util/BdvFunctions.java
+++ b/src/main/java/bdv/util/BdvFunctions.java
@@ -170,7 +170,6 @@ public class BdvFunctions
 		return show( source, Bdv.options() );
 	}
 
-	// TODO version with numTimepoints argument
 	public static < T > BdvStackSource< T > show(
 			final Source< T > source,
 			final BdvOptions options )
@@ -179,9 +178,30 @@ public class BdvFunctions
 		final BdvHandle handle = ( bdv == null )
 				? new BdvHandleFrame( options )
 				: bdv.getBdvHandle();
-		final int numTimepoints = 1;
+		final int numTimePoints = 1;
 		@SuppressWarnings( { "unchecked", "rawtypes" } )
-		final BdvStackSource< T > stackSource = addSource( handle, ( Source ) source, numTimepoints );
+		final BdvStackSource< T > stackSource = addSource( handle, ( Source ) source, numTimePoints );
+		return stackSource;
+	}
+
+	public static < T > BdvStackSource< T > show(
+			final Source< T > source,
+			final int numTimePoints )
+	{
+		return show( source, numTimePoints, Bdv.options() );
+	}
+
+	public static < T > BdvStackSource< T > show(
+			final Source< T > source,
+			final int numTimePoints,
+			final BdvOptions options )
+	{
+		final Bdv bdv = options.values.addTo();
+		final BdvHandle handle = ( bdv == null )
+				? new BdvHandleFrame( options )
+				: bdv.getBdvHandle();
+		@SuppressWarnings( { "unchecked", "rawtypes" } )
+		final BdvStackSource< T > stackSource = addSource( handle, ( Source ) source, numTimePoints );
 		return stackSource;
 	}
 

--- a/src/main/java/bdv/util/BdvFunctions.java
+++ b/src/main/java/bdv/util/BdvFunctions.java
@@ -174,14 +174,7 @@ public class BdvFunctions
 			final Source< T > source,
 			final BdvOptions options )
 	{
-		final Bdv bdv = options.values.addTo();
-		final BdvHandle handle = ( bdv == null )
-				? new BdvHandleFrame( options )
-				: bdv.getBdvHandle();
-		final int numTimePoints = 1;
-		@SuppressWarnings( { "unchecked", "rawtypes" } )
-		final BdvStackSource< T > stackSource = addSource( handle, ( Source ) source, numTimePoints );
-		return stackSource;
+		return show( source, 1, options );
 	}
 
 	public static < T > BdvStackSource< T > show(

--- a/src/test/java/bdv/util/Example4D.java
+++ b/src/test/java/bdv/util/Example4D.java
@@ -1,0 +1,23 @@
+package bdv.util;
+
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.basictypeaccess.array.IntArray;
+import net.imglib2.type.numeric.ARGBType;
+import net.imglib2.util.Util;
+
+import java.util.Random;
+
+public class Example4D
+{
+	public static void main( String[] args )
+	{
+		final Random random = new Random();
+
+		final ArrayImg< ARGBType, IntArray > img = ArrayImgs.argbs( 100, 100, 100, 5 );
+		img.forEach( t -> t.set( random.nextInt() & 0xFF00FF00 ) );
+
+		BdvFunctions.show( img, "4d rai" );
+
+	}
+}

--- a/src/test/java/bdv/util/ExampleSource4D.java
+++ b/src/test/java/bdv/util/ExampleSource4D.java
@@ -1,0 +1,28 @@
+package bdv.util;
+
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.basictypeaccess.array.IntArray;
+import net.imglib2.type.numeric.ARGBType;
+import net.imglib2.util.Util;
+
+import java.util.Random;
+
+public class ExampleSource4D
+{
+	public static void main( String[] args )
+	{
+		final Random random = new Random();
+
+		final ArrayImg< ARGBType, IntArray > img = ArrayImgs.argbs( 100, 100, 100, 5 );
+		img.forEach( t -> t.set( random.nextInt() & 0xFF00FF00 ) );
+
+		final RandomAccessibleIntervalSource4D raiSource4D
+				= new RandomAccessibleIntervalSource4D(
+				img,
+				Util.getTypeFromInterval( img ),
+				"4d rai source" );
+
+		BdvFunctions.show( raiSource4D, 5 );
+	}
+}


### PR DESCRIPTION
Added a version of `BdvFunctions.show` for a `source` with `numTimepoints` argument. Also added an `ExampleSource4D` in `src/test/...` demonstrating the functionality. It would be nice if this could be merged (or differently resolved) as I need the functionality for a project. 

Conceptually, I do not really understand why a `source` does not itself know how many time-points it has? One can currently say `source.isPresent( t )`, but not `source.getNumTimepoints()`. I would be curious to why that is designed like this.  If there was a `source.getNumTimepoints()` function, one would not need to _manually_  specify the number of time-points in `BdvFunctions.show()`.