### PR TITLE
VolatileViews with Invalidate

### DIFF
--- a/src/main/java/bdv/util/volatiles/VolatileRandomAccessibleIntervalView.java
+++ b/src/main/java/bdv/util/volatiles/VolatileRandomAccessibleIntervalView.java
@@ -1,5 +1,7 @@
 package bdv.util.volatiles;
 
+import java.util.function.Predicate;
+
 import net.imglib2.AbstractWrappedInterval;
 import net.imglib2.Interval;
 import net.imglib2.RandomAccess;
@@ -7,11 +9,9 @@ import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.Volatile;
 import net.imglib2.cache.Invalidate;
 
-import java.util.function.Predicate;
-
 public class VolatileRandomAccessibleIntervalView< T, V extends Volatile< T > >
-	extends AbstractWrappedInterval< RandomAccessibleInterval< V > >
-	implements VolatileView< T, V >, RandomAccessibleInterval< V >, Invalidate< Long >
+		extends AbstractWrappedInterval< RandomAccessibleInterval< V > >
+		implements VolatileView< T, V >, RandomAccessibleInterval< V >, Invalidate< Long >
 {
 	private final VolatileViewData< T, V > viewData;
 
@@ -41,17 +41,20 @@ public class VolatileRandomAccessibleIntervalView< T, V extends Volatile< T > >
 	}
 
 	@Override
-	public void invalidate(Long key) {
-		this.viewData.invalidate(key);
+	public void invalidate( Long key )
+	{
+		this.viewData.invalidate( key );
 	}
 
 	@Override
-	public void invalidateIf(long parallelismThreshold, Predicate<Long> condition) {
-		this.viewData.invalidateIf(parallelismThreshold, condition);
+	public void invalidateIf( long parallelismThreshold, Predicate< Long > condition )
+	{
+		this.viewData.invalidateIf( parallelismThreshold, condition );
 	}
 
 	@Override
-	public void invalidateAll(long parallelismThreshold) {
-		this.viewData.invalidateAll(parallelismThreshold);
+	public void invalidateAll( long parallelismThreshold )
+	{
+		this.viewData.invalidateAll( parallelismThreshold );
 	}
 }

--- a/src/main/java/bdv/util/volatiles/VolatileRandomAccessibleIntervalView.java
+++ b/src/main/java/bdv/util/volatiles/VolatileRandomAccessibleIntervalView.java
@@ -5,10 +5,13 @@ import net.imglib2.Interval;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.Volatile;
+import net.imglib2.cache.Invalidate;
+
+import java.util.function.Predicate;
 
 public class VolatileRandomAccessibleIntervalView< T, V extends Volatile< T > >
 	extends AbstractWrappedInterval< RandomAccessibleInterval< V > >
-	implements VolatileView< T, V >, RandomAccessibleInterval< V >
+	implements VolatileView< T, V >, RandomAccessibleInterval< V >, Invalidate< Long >
 {
 	private final VolatileViewData< T, V > viewData;
 
@@ -35,5 +38,20 @@ public class VolatileRandomAccessibleIntervalView< T, V extends Volatile< T > >
 	public RandomAccess< V > randomAccess( final Interval interval )
 	{
 		return sourceInterval.randomAccess( interval );
+	}
+
+	@Override
+	public void invalidate(Long key) {
+		this.viewData.invalidate(key);
+	}
+
+	@Override
+	public void invalidateIf(long parallelismThreshold, Predicate<Long> condition) {
+		this.viewData.invalidateIf(parallelismThreshold, condition);
+	}
+
+	@Override
+	public void invalidateAll(long parallelismThreshold) {
+		this.viewData.invalidateAll(parallelismThreshold);
 	}
 }

--- a/src/main/java/bdv/util/volatiles/VolatileViewData.java
+++ b/src/main/java/bdv/util/volatiles/VolatileViewData.java
@@ -4,6 +4,7 @@ import bdv.cache.CacheControl;
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.Volatile;
+import net.imglib2.cache.Invalidate;
 import net.imglib2.cache.img.CachedCellImg;
 
 /**
@@ -33,16 +34,20 @@ public class VolatileViewData< T, V extends Volatile< T > >
 
 	private final V volatileType;
 
+	private final Invalidate< ? > invalidate;
+
 	public VolatileViewData(
 			final RandomAccessible< V > img,
 			final CacheControl cacheControl,
 			final T type,
-			final V volatileType )
+			final V volatileType,
+			final Invalidate< ? > invalidate )
 	{
 		this.img = img;
 		this.cacheControl = cacheControl;
 		this.type = type;
 		this.volatileType = volatileType;
+		this.invalidate = invalidate;
 	}
 
 	/**
@@ -85,5 +90,10 @@ public class VolatileViewData< T, V extends Volatile< T > >
 	public V getVolatileType()
 	{
 		return volatileType;
+	}
+
+	public Invalidate< ? > getInvalidate()
+	{
+		return this.invalidate;
 	}
 }

--- a/src/main/java/bdv/util/volatiles/VolatileViewData.java
+++ b/src/main/java/bdv/util/volatiles/VolatileViewData.java
@@ -7,6 +7,8 @@ import net.imglib2.Volatile;
 import net.imglib2.cache.Invalidate;
 import net.imglib2.cache.img.CachedCellImg;
 
+import java.util.function.Predicate;
+
 /**
  * Metadata associated with a {@link VolatileView}. It comprises the types
  * of the original and volatile image, a {@link CacheControl} for the
@@ -24,7 +26,7 @@ import net.imglib2.cache.img.CachedCellImg;
  *
  * @author Tobias Pietzsch
  */
-public class VolatileViewData< T, V extends Volatile< T > >
+public class VolatileViewData< T, V extends Volatile< T > > implements Invalidate< Long >
 {
 	private final RandomAccessible< V > img;
 
@@ -34,14 +36,14 @@ public class VolatileViewData< T, V extends Volatile< T > >
 
 	private final V volatileType;
 
-	private final Invalidate< ? > invalidate;
+	private final Invalidate< Long > invalidate;
 
 	public VolatileViewData(
 			final RandomAccessible< V > img,
 			final CacheControl cacheControl,
 			final T type,
 			final V volatileType,
-			final Invalidate< ? > invalidate )
+			final Invalidate< Long > invalidate )
 	{
 		this.img = img;
 		this.cacheControl = cacheControl;
@@ -92,8 +94,23 @@ public class VolatileViewData< T, V extends Volatile< T > >
 		return volatileType;
 	}
 
-	public Invalidate< ? > getInvalidate()
+	public Invalidate< Long > getInvalidate()
 	{
 		return this.invalidate;
+	}
+
+	@Override
+	public void invalidate(Long key) {
+		this.invalidate.invalidate(key);
+	}
+
+	@Override
+	public void invalidateIf(long parallelismThreshold, Predicate<Long> condition) {
+		this.invalidate.invalidateIf(parallelismThreshold, condition);
+	}
+
+	@Override
+	public void invalidateAll(long parallelismThreshold) {
+		this.invalidate.invalidateAll(parallelismThreshold);
 	}
 }

--- a/src/main/java/bdv/util/volatiles/VolatileViewData.java
+++ b/src/main/java/bdv/util/volatiles/VolatileViewData.java
@@ -1,13 +1,13 @@
 package bdv.util.volatiles;
 
+import java.util.function.Predicate;
+
 import bdv.cache.CacheControl;
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.Volatile;
 import net.imglib2.cache.Invalidate;
 import net.imglib2.cache.img.CachedCellImg;
-
-import java.util.function.Predicate;
 
 /**
  * Metadata associated with a {@link VolatileView}. It comprises the types
@@ -100,17 +100,20 @@ public class VolatileViewData< T, V extends Volatile< T > > implements Invalidat
 	}
 
 	@Override
-	public void invalidate(Long key) {
-		this.invalidate.invalidate(key);
+	public void invalidate( Long key )
+	{
+		this.invalidate.invalidate( key );
 	}
 
 	@Override
-	public void invalidateIf(long parallelismThreshold, Predicate<Long> condition) {
-		this.invalidate.invalidateIf(parallelismThreshold, condition);
+	public void invalidateIf( long parallelismThreshold, Predicate< Long > condition )
+	{
+		this.invalidate.invalidateIf( parallelismThreshold, condition );
 	}
 
 	@Override
-	public void invalidateAll(long parallelismThreshold) {
-		this.invalidate.invalidateAll(parallelismThreshold);
+	public void invalidateAll( long parallelismThreshold )
+	{
+		this.invalidate.invalidateAll( parallelismThreshold );
 	}
 }

--- a/src/main/java/bdv/util/volatiles/VolatileViews.java
+++ b/src/main/java/bdv/util/volatiles/VolatileViews.java
@@ -1,7 +1,10 @@
 package bdv.util.volatiles;
 
-import bdv.img.cache.CreateInvalidVolatileCell;
-import bdv.img.cache.VolatileCachedCellImg;
+import static net.imglib2.img.basictypeaccess.AccessFlags.DIRTY;
+import static net.imglib2.img.basictypeaccess.AccessFlags.VOLATILE;
+
+import java.util.Set;
+
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.Volatile;
@@ -21,10 +24,8 @@ import net.imglib2.type.NativeType;
 import net.imglib2.view.IntervalView;
 import net.imglib2.view.MixedTransformView;
 
-import java.util.Set;
-
-import static net.imglib2.img.basictypeaccess.AccessFlags.DIRTY;
-import static net.imglib2.img.basictypeaccess.AccessFlags.VOLATILE;
+import bdv.img.cache.CreateInvalidVolatileCell;
+import bdv.img.cache.VolatileCachedCellImg;
 
 /**
  * Wrap view cascades ending in {@link CachedCellImg} as volatile views.
@@ -152,14 +153,14 @@ public class VolatileViews
 		if ( hints == null )
 			hints = new CacheHints( LoadingStrategy.VOLATILE, 0, false );
 		@SuppressWarnings( "rawtypes" )
-		final VolatileCache<Long, Cell<? extends VolatileArrayDataAccess< ? >>> volatileCache = createVolatileCache( grid, vtype, dirty, ( Cache ) cache, queue );
+		final VolatileCache< Long, Cell< ? extends VolatileArrayDataAccess< ? > > > volatileCache = createVolatileCache( grid, vtype, dirty, ( Cache ) cache, queue );
 
 		final VolatileCachedCellImg< V, ? extends VolatileArrayDataAccess< ? > > volatileImg = new VolatileCachedCellImg<>( grid, vtype, hints, volatileCache.unchecked()::get );
 
 		return new VolatileViewData<>( volatileImg, queue, type, vtype, volatileCache );
 	}
 
-	private static < T extends NativeType< T >, A extends VolatileArrayDataAccess< A > > VolatileCache<Long, Cell<A>> createVolatileCache(
+	private static < T extends NativeType< T >, A extends VolatileArrayDataAccess< A > > VolatileCache< Long, Cell< A > > createVolatileCache(
 			final CellGrid grid,
 			final T type,
 			final boolean dirty,


### PR DESCRIPTION
This PR exposes the `Invalidate` interface of  the volatile cache when wrapping a `RandomAccessibleInterval` with `VolatileViews.wrapAsVolatile` as discussed [on gitter](https://gitter.im/bigdataviewer/bigdataviewer-core?at=5d78c2743b1e5e5df18eff0c):

 1. Refactor `VolatileViews.createVolatileCachedCellImg` to `VolatileViews.createVolatileCache` to get access to cache
 2. Have `VolatileViewData` implement `Invalidate<Long>` to expose the volatile cache's `Invalidate`.
   - Delegate to `invalidate` that is passed in constructor
   - This could possibly be `Invalidate<K>`, but would add generic parameter
 3. Have `VolatileRandomAccessibleIntervalView` implement `Invalidate<Long>`
   - Makes it easy to check downstream, just check for `rai instanceof Invalidate<?>`
   - Could be useful for `CachedCellImg` as well for the same reason.

This should probably bye squashed into a single commit upon merge.