### PR TITLE
Show SourceAndConverter

### DIFF
--- a/src/main/java/bdv/util/BdvFunctions.java
+++ b/src/main/java/bdv/util/BdvFunctions.java
@@ -184,6 +184,13 @@ public class BdvFunctions
 	}
 
 	public static < T > BdvStackSource< T > show(
+			final SourceAndConverter< T > sourceAndConverter,
+			final int numTimePoints )
+	{
+		return show( sourceAndConverter, numTimePoints, Bdv.options() );
+	}
+
+	public static < T > BdvStackSource< T > show(
 			final Source< T > source,
 			final int numTimePoints,
 			final BdvOptions options )
@@ -194,6 +201,20 @@ public class BdvFunctions
 				: bdv.getBdvHandle();
 		@SuppressWarnings( { "unchecked", "rawtypes" } )
 		final BdvStackSource< T > stackSource = addSource( handle, ( Source ) source, numTimePoints );
+		return stackSource;
+	}
+
+	public static < T > BdvStackSource< T > show(
+			final SourceAndConverter< T > sourceAndConverter,
+			final int numTimePoints,
+			final BdvOptions options )
+	{
+		final Bdv bdv = options.values.addTo();
+		final BdvHandle handle = ( bdv == null )
+				? new BdvHandleFrame( options )
+				: bdv.getBdvHandle();
+		@SuppressWarnings( { "unchecked", "rawtypes" } )
+		final BdvStackSource< T > stackSource = addSourceAndConverter( handle, sourceAndConverter, numTimePoints );
 		return stackSource;
 	}
 
@@ -573,6 +594,36 @@ public class BdvFunctions
 		final List< ConverterSetup > converterSetups = new ArrayList<>();
 		final List< SourceAndConverter< T > > sources = new ArrayList<>();
 		addSourceToListsGenericType( source, handle.getUnusedSetupId(), converterSetups, sources );
+		handle.add( converterSetups, sources, numTimepoints );
+		final BdvStackSource< T > bdvSource = new BdvStackSource<>( handle, numTimepoints, type, converterSetups, sources );
+		handle.addBdvSource( bdvSource );
+		return bdvSource;
+	}
+
+	/**
+	 * Add the given {@link SourceAndConverter} to the given {@link BdvHandle} as a new
+	 * {@link BdvStackSource}.
+	 *
+	 * @param handle
+	 *            handle to add the {@code source} to.
+	 * @param soc
+	 *            sourceAndConverter to add.
+	 * @param numTimepoints
+	 *            the number of timepoints of the source.
+	 * @return a new {@link BdvStackSource} handle for the newly added
+	 *         {@code source}.
+	 */
+	@SuppressWarnings( "rawtypes" )
+	private static < T > BdvStackSource< T > addSourceAndConverter(
+			final BdvHandle handle,
+			final SourceAndConverter< T > soc,
+			final int numTimepoints )
+	{
+		final T type = soc.getSpimSource().getType();
+		final List< ConverterSetup > converterSetups = new ArrayList<>();
+		final List< SourceAndConverter< T > > sources = new ArrayList<>();
+		converterSetups.add( BigDataViewer.createConverterSetup( soc, handle.getUnusedSetupId() ) );
+		sources.add( soc );
 		handle.add( converterSetups, sources, numTimepoints );
 		final BdvStackSource< T > bdvSource = new BdvStackSource<>( handle, numTimepoints, type, converterSetups, sources );
 		handle.addBdvSource( bdvSource );

--- a/src/main/java/bdv/util/BdvFunctions.java
+++ b/src/main/java/bdv/util/BdvFunctions.java
@@ -185,6 +185,12 @@ public class BdvFunctions
 	}
 
 	public static < T > BdvStackSource< T > show(
+			final SourceAndConverter< T > sourceAndConverter )
+	{
+		return show( sourceAndConverter, 1, Bdv.options() );
+	}
+
+	public static < T > BdvStackSource< T > show(
 			final SourceAndConverter< T > sourceAndConverter,
 			final int numTimePoints )
 	{

--- a/src/main/java/bdv/util/BdvFunctions.java
+++ b/src/main/java/bdv/util/BdvFunctions.java
@@ -12,6 +12,7 @@ import net.imglib2.RealInterval;
 import net.imglib2.RealLocalizable;
 import net.imglib2.RealRandomAccessible;
 import net.imglib2.converter.Converter;
+import net.imglib2.display.ColorConverter;
 import net.imglib2.realtransform.AffineTransform3D;
 import net.imglib2.realtransform.RealViews;
 import net.imglib2.type.Type;
@@ -42,6 +43,7 @@ import bdv.viewer.Source;
 import bdv.viewer.SourceAndConverter;
 import mpicbg.spim.data.generic.AbstractSpimData;
 import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
+import sun.jvm.hotspot.utilities.AssertionFailure;
 
 /**
  * all show methods return a {@link Bdv} which can be used to add more stuff to the same window
@@ -209,6 +211,9 @@ public class BdvFunctions
 			final int numTimePoints,
 			final BdvOptions options )
 	{
+		if ( ! ( sourceAndConverter.getConverter() instanceof ColorConverter ) )
+			throw new AssertionError( "The Converter in the SourceAndConverter must be a ColorConverter" );
+
 		final Bdv bdv = options.values.addTo();
 		final BdvHandle handle = ( bdv == null )
 				? new BdvHandleFrame( options )

--- a/src/main/java/bdv/util/BdvFunctions.java
+++ b/src/main/java/bdv/util/BdvFunctions.java
@@ -43,7 +43,6 @@ import bdv.viewer.Source;
 import bdv.viewer.SourceAndConverter;
 import mpicbg.spim.data.generic.AbstractSpimData;
 import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
-import sun.jvm.hotspot.utilities.AssertionFailure;
 
 /**
  * all show methods return a {@link Bdv} which can be used to add more stuff to the same window

--- a/src/test/java/bdv/util/ExampleSourceAndConverter4D.java
+++ b/src/test/java/bdv/util/ExampleSourceAndConverter4D.java
@@ -1,0 +1,44 @@
+package bdv.util;
+
+import bdv.viewer.SourceAndConverter;
+import net.imglib2.converter.Converter;
+import net.imglib2.display.ColorConverter;
+import net.imglib2.display.RealARGBColorConverter;
+import net.imglib2.display.ScaledARGBConverter;
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.basictypeaccess.array.IntArray;
+import net.imglib2.type.numeric.ARGBType;
+import net.imglib2.type.numeric.NumericType;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.util.Util;
+
+import java.util.Random;
+
+public class ExampleSourceAndConverter4D
+{
+	public static < R extends RealType< R > > void main( String[] args )
+	{
+		final Random random = new Random();
+
+		final ArrayImg< IntType, IntArray > ints = ArrayImgs.ints( 100, 100, 100, 5 );
+		ints.forEach( t -> t.set( random.nextInt( 65535 ) ) );
+
+		final IntType t = Util.getTypeFromInterval( ints );
+
+		final RandomAccessibleIntervalSource4D< R > raiSource4D
+				= new RandomAccessibleIntervalSource4D( ints, t, "4d rai source" );
+
+		final double typeMin = Math.max( 0, Math.min( t.getMinValue(), 65535 ) );
+		final double typeMax = Math.max( 0, Math.min( t.getMaxValue(), 65535 ) );
+		final RealARGBColorConverter< IntType > colorConverter = RealARGBColorConverter.create( t, typeMin, typeMax );
+
+		final SourceAndConverter sourceAndConverter
+				= new SourceAndConverter(
+						raiSource4D,
+						colorConverter );
+
+		BdvFunctions.show( sourceAndConverter, 5 );
+	}
+}


### PR DESCRIPTION
Hi @tpietzsch,

I started working on making it possible to show a `SourceAndConverter`. 

This seems to work:
https://github.com/tischi/bigdataviewer-vistools/blob/displaySourceAndConverter/src/test/java/bdv/util/ExampleSourceAndConverter4D.java#L19

However, it will fail if the converter is not a `ColorConverter`, see here: https://github.com/bigdataviewer/bigdataviewer-vistools/issues/37

I think the solution could be to implement a wrapper like sketched below in `net.imglib2.display`:

```
public static class ARGBConverter extends ScaledARGBConverter< ARGBType >
{          
        Converter< ?, ARGBType > converter
		
        public ARGB( final Converter< ?, ARGBType > converter, final double min, final double max )
	{
               this.converter = converter;
 	       super( min, max );
	}

	@Override
	public void convert( final ? input, final ARGBType output )
	{
               converter.convert( input, output );
	       output.set( getScaledColor( output.get() ) );
	}
}
```

, which would be called in case the provided `Converter` is not yet a `ColorConverter`.

What do you think?
