### PR TITLE
infinite source can skip renderer's bounding box intersection test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
 		<license.copyrightOwners>BigDataViewer developers.</license.copyrightOwners>
 		<license.projectName>BigDataViewer quick visualization API.</license.projectName>
 
-		<bigdataviewer-core.version>10.0.0</bigdataviewer-core.version>
+		<bigdataviewer-core.version>10.0.2-SNAPSHOT</bigdataviewer-core.version>
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>deploy-to-scijava</releaseProfiles>

--- a/src/main/java/bdv/util/AbstractSource.java
+++ b/src/main/java/bdv/util/AbstractSource.java
@@ -50,12 +50,23 @@ public abstract class AbstractSource< T extends NumericType< T > > implements So
 
 	protected final DefaultInterpolators< T > interpolators;
 
-	public AbstractSource( final T type, final String name, final VoxelDimensions voxelDimensions )
+	private final boolean doBoundingBoxCulling;
+
+	public AbstractSource( final T type, final String name, final VoxelDimensions voxelDimensions, final boolean doBoundingBoxCulling )
 	{
 		this.type = tryCreateVariable( type );
 		this.name = name;
 		this.voxelDimensions = voxelDimensions;
 		interpolators = new DefaultInterpolators<>();
+		this.doBoundingBoxCulling = doBoundingBoxCulling;
+	}
+
+	public AbstractSource( final T type, final String name, final VoxelDimensions voxelDimensions )
+	{
+		/**
+		 * Do bounding box culling by default
+		 */
+		this( type, name, voxelDimensions, true );
 	}
 
 	public AbstractSource( final T type, final String name )
@@ -65,7 +76,12 @@ public abstract class AbstractSource< T extends NumericType< T > > implements So
 		 * DefaultVoxelDimensionsimplementation will return the same result 
 		 * for spacing and units regardless of the number of dimensions passed. 
 		 */
-		this( type, name, new DefaultVoxelDimensions( -1 ));
+		this( type, name, new DefaultVoxelDimensions( -1 ), true );
+	}
+
+	public AbstractSource( final T type, final String name, final boolean doBoundingBoxCulling )
+	{
+		this( type, name, new DefaultVoxelDimensions( -1 ), doBoundingBoxCulling );
 	}
 
 	public AbstractSource( final Supplier< T > typeSupplier, final String name )
@@ -107,6 +123,12 @@ public abstract class AbstractSource< T extends NumericType< T > > implements So
 	public int getNumMipmapLevels()
 	{
 		return 1;
+	}
+
+	@Override
+	public boolean doBoundingBoxCulling()
+	{
+		return doBoundingBoxCulling;
 	}
 
 	static < T > T tryCreateVariable( final T t )

--- a/src/main/java/bdv/util/RandomAccessibleSource.java
+++ b/src/main/java/bdv/util/RandomAccessibleSource.java
@@ -55,7 +55,7 @@ public class RandomAccessibleSource< T extends NumericType< T > > extends Abstra
 			final T type,
 			final String name )
 	{
-		this( img, interval, type, new AffineTransform3D(), name );
+		this( img, interval, type, new AffineTransform3D(), name, false );
 	}
 
 	public RandomAccessibleSource(
@@ -65,7 +65,7 @@ public class RandomAccessibleSource< T extends NumericType< T > > extends Abstra
 			final AffineTransform3D sourceTransform,
 			final String name )
 	{
-		this( img, interval, type, sourceTransform, name, true );
+		this( img, interval, type, sourceTransform, name, false );
 	}
 
 	public RandomAccessibleSource(

--- a/src/main/java/bdv/util/RandomAccessibleSource.java
+++ b/src/main/java/bdv/util/RandomAccessibleSource.java
@@ -47,8 +47,6 @@ public class RandomAccessibleSource< T extends NumericType< T > > extends Abstra
 
 	private final AffineTransform3D sourceTransform;
 
-	private final boolean doBoundingBoxCulling;
-
 	public RandomAccessibleSource(
 			final RandomAccessible< T > img,
 			final Interval interval,
@@ -76,21 +74,14 @@ public class RandomAccessibleSource< T extends NumericType< T > > extends Abstra
 			final String name,
 			final boolean doBoundingBoxCulling )
 	{
-		super( type, name );
+		super( type, name, doBoundingBoxCulling );
 		this.source = img;
 		this.interval = interval;
 		this.sourceTransform = sourceTransform;
-		this.doBoundingBoxCulling = doBoundingBoxCulling;
 		interpolatedSources = new RealRandomAccessible[ Interpolation.values().length ];
 		for ( final Interpolation method : Interpolation.values() )
 			interpolatedSources[ method.ordinal() ] = Views.interpolate( source, interpolators.get( method ) );
 
-	}
-
-	@Override
-	public boolean doBoundingBoxCulling()
-	{
-		return doBoundingBoxCulling;
 	}
 
 	@Override

--- a/src/main/java/bdv/util/RandomAccessibleSource.java
+++ b/src/main/java/bdv/util/RandomAccessibleSource.java
@@ -74,6 +74,12 @@ public class RandomAccessibleSource< T extends NumericType< T > > extends Abstra
 	}
 
 	@Override
+	public boolean doBoundingBoxIntersectionCheck()
+	{
+		return false;
+	}
+
+	@Override
 	public RandomAccessibleInterval< T > getSource( final int t, final int level )
 	{
 		return Views.interval( source, interval );

--- a/src/main/java/bdv/util/RandomAccessibleSource.java
+++ b/src/main/java/bdv/util/RandomAccessibleSource.java
@@ -47,6 +47,8 @@ public class RandomAccessibleSource< T extends NumericType< T > > extends Abstra
 
 	private final AffineTransform3D sourceTransform;
 
+	private final boolean doBoundingBoxIntersectionCheck;
+
 	public RandomAccessibleSource(
 			final RandomAccessible< T > img,
 			final Interval interval,
@@ -63,10 +65,22 @@ public class RandomAccessibleSource< T extends NumericType< T > > extends Abstra
 			final AffineTransform3D sourceTransform,
 			final String name )
 	{
+		this( img, interval, type, sourceTransform, name, true );
+	}
+
+	public RandomAccessibleSource(
+			final RandomAccessible< T > img,
+			final Interval interval,
+			final T type,
+			final AffineTransform3D sourceTransform,
+			final String name,
+			final boolean doBoundingBoxIntersectionCheck )
+	{
 		super( type, name );
 		this.source = img;
 		this.interval = interval;
 		this.sourceTransform = sourceTransform;
+		this.doBoundingBoxIntersectionCheck = doBoundingBoxIntersectionCheck;
 		interpolatedSources = new RealRandomAccessible[ Interpolation.values().length ];
 		for ( final Interpolation method : Interpolation.values() )
 			interpolatedSources[ method.ordinal() ] = Views.interpolate( source, interpolators.get( method ) );
@@ -76,7 +90,7 @@ public class RandomAccessibleSource< T extends NumericType< T > > extends Abstra
 	@Override
 	public boolean doBoundingBoxIntersectionCheck()
 	{
-		return false;
+		return doBoundingBoxIntersectionCheck;
 	}
 
 	@Override

--- a/src/main/java/bdv/util/RandomAccessibleSource4D.java
+++ b/src/main/java/bdv/util/RandomAccessibleSource4D.java
@@ -56,13 +56,24 @@ public class RandomAccessibleSource4D< T extends NumericType< T > > extends Abst
 
 	private final AffineTransform3D sourceTransform;
 
+	private final boolean doBoundingBoxIntersectionCheck;
+
 	public RandomAccessibleSource4D(
 			final RandomAccessible< T > img,
 			final Interval interval,
 			final T type,
 			final String name )
 	{
-		this( img, interval, type, new AffineTransform3D(), name );
+		this( img, interval, type, new AffineTransform3D(), name, false );
+	}
+	public RandomAccessibleSource4D(
+			final RandomAccessible< T > img,
+			final Interval interval,
+			final T type,
+			final AffineTransform3D sourceTransform,
+			final String name )
+	{
+		this( img, interval, type, sourceTransform, name, false );
 	}
 
 	public RandomAccessibleSource4D(
@@ -70,7 +81,8 @@ public class RandomAccessibleSource4D< T extends NumericType< T > > extends Abst
 			final Interval interval,
 			final T type,
 			final AffineTransform3D sourceTransform,
-			final String name )
+			final String name,
+			final boolean doBoundingBoxIntersectionCheck )
 	{
 		super( type, name );
 		this.source = img;
@@ -79,8 +91,15 @@ public class RandomAccessibleSource4D< T extends NumericType< T > > extends Abst
 				interval.min( 0 ), interval.min( 1 ), interval.min( 2 ),
 				interval.max( 0 ), interval.max( 1 ), interval.max( 2 ) );
 		this.sourceTransform = sourceTransform;
+		this.doBoundingBoxIntersectionCheck = doBoundingBoxIntersectionCheck;
 		currentInterpolatedSources = new RealRandomAccessible[ Interpolation.values().length ];
 		loadTimepoint( 0 );
+	}
+
+	@Override
+	public boolean doBoundingBoxIntersectionCheck()
+	{
+		return doBoundingBoxIntersectionCheck;
 	}
 
 	private void loadTimepoint( final int timepointIndex )

--- a/src/main/java/bdv/util/RandomAccessibleSource4D.java
+++ b/src/main/java/bdv/util/RandomAccessibleSource4D.java
@@ -56,8 +56,6 @@ public class RandomAccessibleSource4D< T extends NumericType< T > > extends Abst
 
 	private final AffineTransform3D sourceTransform;
 
-	private final boolean doBoundingBoxCulling;
-
 	public RandomAccessibleSource4D(
 			final RandomAccessible< T > img,
 			final Interval interval,
@@ -84,22 +82,15 @@ public class RandomAccessibleSource4D< T extends NumericType< T > > extends Abst
 			final String name,
 			final boolean doBoundingBoxCulling )
 	{
-		super( type, name );
+		super( type, name, doBoundingBoxCulling );
 		this.source = img;
 		this.interval = interval;
 		this.timeSliceInterval = Intervals.createMinMax(
 				interval.min( 0 ), interval.min( 1 ), interval.min( 2 ),
 				interval.max( 0 ), interval.max( 1 ), interval.max( 2 ) );
 		this.sourceTransform = sourceTransform;
-		this.doBoundingBoxCulling = doBoundingBoxCulling;
 		currentInterpolatedSources = new RealRandomAccessible[ Interpolation.values().length ];
 		loadTimepoint( 0 );
-	}
-
-	@Override
-	public boolean doBoundingBoxCulling()
-	{
-		return doBoundingBoxCulling;
 	}
 
 	private void loadTimepoint( final int timepointIndex )

--- a/src/main/java/bdv/util/RealRandomAccessibleIntervalSource.java
+++ b/src/main/java/bdv/util/RealRandomAccessibleIntervalSource.java
@@ -55,7 +55,18 @@ public class RealRandomAccessibleIntervalSource< T extends Type< T > > extends R
 			final AffineTransform3D sourceTransform,
 			final String name )
 	{
-		super( accessible, type, name );
+		this( accessible, interval, type, sourceTransform, name, false );
+	}
+
+	public RealRandomAccessibleIntervalSource(
+			final RealRandomAccessible< T > accessible,
+			final Interval interval,
+			final T type,
+			final AffineTransform3D sourceTransform,
+			final String name,
+			final boolean doBoundingBoxIntersectionCheck )
+	{
+		super( accessible, type, name, null, doBoundingBoxIntersectionCheck );
 		this.interval = interval;
 		this.sourceTransform = sourceTransform;
 	}

--- a/src/main/java/bdv/util/RealRandomAccessibleIntervalSource.java
+++ b/src/main/java/bdv/util/RealRandomAccessibleIntervalSource.java
@@ -28,6 +28,7 @@
  */
 package bdv.util;
 
+import mpicbg.spim.data.sequence.DefaultVoxelDimensions;
 import net.imglib2.Interval;
 import net.imglib2.RealRandomAccessible;
 import net.imglib2.realtransform.AffineTransform3D;
@@ -66,7 +67,7 @@ public class RealRandomAccessibleIntervalSource< T extends Type< T > > extends R
 			final String name,
 			final boolean doBoundingBoxIntersectionCheck )
 	{
-		super( accessible, type, name, null, doBoundingBoxIntersectionCheck );
+		super( accessible, type, name, new DefaultVoxelDimensions( -1 ), doBoundingBoxIntersectionCheck );
 		this.interval = interval;
 		this.sourceTransform = sourceTransform;
 	}

--- a/src/main/java/bdv/util/RealRandomAccessibleIntervalSource.java
+++ b/src/main/java/bdv/util/RealRandomAccessibleIntervalSource.java
@@ -45,7 +45,7 @@ public class RealRandomAccessibleIntervalSource< T extends Type< T > > extends R
 			final T type,
 			final String name )
 	{
-		this( accessible, interval, type, new AffineTransform3D(), name );
+		this( accessible, interval, type, new AffineTransform3D(), name, false );
 	}
 
 	public RealRandomAccessibleIntervalSource(


### PR DESCRIPTION
Depends on: https://github.com/bigdataviewer/bigdataviewer-core/pull/110

Added a constructor to `RandomAccessibleSource` setting the value of an immutable flag.
* Do we want the flag to be immutable or set-able?

## Example
Test with the following:
```
FunctionRandomAccessible ra = new FunctionRandomAccessible<>( 3, 
			(x,v) -> v.set( x.getDoublePosition( 0 )) , 
			DoubleType::new );

RandomAccessibleSource srcFlag = new RandomAccessibleSource( 
		ra,
		new FinalInterval(50,50,50),
		new DoubleType(),
		"xcoord");

RandomAccessibleSource srcNoFlag = new RandomAccessibleSource( 
		ra,
		new FinalInterval(50,50,50),
		new DoubleType(),
		new AffineTransform3D(),
		"xcoord",
		false );

BdvStackSource bdv = BdvFunctions.show( srcFlag );
bdv.setDisplayRangeBounds( 0, 100 );

bdv = BdvFunctions.show( srcNoFlag, BdvOptions.options().addTo( bdv ));
bdv.setDisplayRangeBounds( 0, 100 );
```

* Observe that first source appears only when part of the interval [50,50,50] is on screen (current behavior)
* Observe that second source alwasys appears(new behavior)