### PR TITLE
Bump to bigdataviewer-core 10.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>31.0.0</version>
+		<version>32.0.0-beta-4</version>
 		<relativePath />
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -154,9 +154,23 @@
 			<groupId>org.scijava</groupId>
 			<artifactId>ui-behaviour</artifactId>
 		</dependency>
+
+		<!-- test dependencies -->
+		<!-- JUnit -->
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<!-- JMH -->
+		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-generator-annprocess</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,8 @@
 		<license.copyrightOwners>BigDataViewer developers.</license.copyrightOwners>
 		<license.projectName>BigDataViewer quick visualization API.</license.projectName>
 
-		<bigdataviewer-core.version>10.2.1</bigdataviewer-core.version>
+		<ui-behaviour.version>2.0.6</ui-behaviour.version>
+		<bigdataviewer-core.version>10.4.1</bigdataviewer-core.version>
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>

--- a/src/main/java/bdv/util/BdvHandle.java
+++ b/src/main/java/bdv/util/BdvHandle.java
@@ -29,6 +29,8 @@
 package bdv.util;
 
 import bdv.ui.CardPanel;
+import bdv.ui.appearance.AppearanceManager;
+import bdv.ui.keymap.KeymapManager;
 import bdv.ui.splitpanel.SplitPanel;
 import bdv.viewer.ConverterSetups;
 import bdv.viewer.ViewerStateChangeListener;
@@ -123,6 +125,10 @@ public abstract class BdvHandle implements Bdv
 	{
 		return cacheControls;
 	}
+
+	public abstract KeymapManager getKeymapManager();
+
+	public abstract AppearanceManager getAppearanceManager();
 
 	@Deprecated
 	int getUnusedSetupId()

--- a/src/main/java/bdv/util/BdvHandleFrame.java
+++ b/src/main/java/bdv/util/BdvHandleFrame.java
@@ -28,13 +28,14 @@
  */
 package bdv.util;
 
+import bdv.ui.appearance.AppearanceManager;
+import bdv.ui.keymap.KeymapManager;
 import bdv.viewer.ViewerStateChange;
 import java.awt.event.WindowEvent;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.scijava.ui.behaviour.io.InputTriggerConfig;
-import org.scijava.ui.behaviour.util.Actions;
 import org.scijava.ui.behaviour.util.InputActionBindings;
 import org.scijava.ui.behaviour.util.TriggerBehaviourBindings;
 
@@ -45,7 +46,6 @@ import bdv.export.ProgressWriterConsole;
 import bdv.tools.brightness.ConverterSetup;
 import bdv.tools.transformation.ManualTransformationEditor;
 import bdv.viewer.DisplayMode;
-import bdv.viewer.NavigationActions;
 import bdv.viewer.SourceAndConverter;
 import bdv.viewer.ViewerFrame;
 import bdv.viewer.ViewerOptions;
@@ -85,6 +85,18 @@ public class BdvHandleFrame extends BdvHandle
 	public ManualTransformationEditor getManualTransformEditor()
 	{
 		return bdv.getManualTransformEditor();
+	}
+
+	@Override
+	public KeymapManager getKeymapManager()
+	{
+		return bdv.getKeymapManager();
+	}
+
+	@Override
+	public AppearanceManager getAppearanceManager()
+	{
+		return bdv.getAppearanceManager();
 	}
 
 	@Override

--- a/src/main/java/bdv/util/BdvHandleFrame.java
+++ b/src/main/java/bdv/util/BdvHandleFrame.java
@@ -28,6 +28,7 @@
  */
 package bdv.util;
 
+import bdv.ui.UIUtils;
 import bdv.ui.appearance.AppearanceManager;
 import bdv.ui.keymap.KeymapManager;
 import bdv.viewer.ViewerStateChange;
@@ -62,6 +63,7 @@ public class BdvHandleFrame extends BdvHandle
 		frameTitle = options.values.getFrameTitle();
 		bdv = null;
 		cacheControls = new CacheControls();
+		UIUtils.installFlatLafInfos();
 	}
 
 	public BigDataViewer getBigDataViewer()

--- a/src/main/java/bdv/util/BdvHandlePanel.java
+++ b/src/main/java/bdv/util/BdvHandlePanel.java
@@ -30,6 +30,7 @@ package bdv.util;
 
 import bdv.ui.BdvDefaultCards;
 import bdv.ui.CardPanel;
+import bdv.ui.UIUtils;
 import bdv.ui.appearance.AppearanceManager;
 import bdv.ui.keymap.KeymapManager;
 import bdv.ui.splitpanel.SplitPanel;
@@ -94,6 +95,7 @@ public class BdvHandlePanel extends BdvHandle
 	public BdvHandlePanel( final Frame dialogOwner, final BdvOptions options )
 	{
 		super( options );
+		UIUtils.installFlatLafInfos();
 
 		final KeymapManager optionsKeymapManager = options.values.getKeymapManager();
 		final AppearanceManager optionsAppearanceManager = options.values.getAppearanceManager();

--- a/src/main/java/bdv/util/BdvOptions.java
+++ b/src/main/java/bdv/util/BdvOptions.java
@@ -31,6 +31,8 @@ package bdv.util;
 import bdv.TransformEventHandler2D;
 import bdv.TransformEventHandler3D;
 import bdv.TransformEventHandlerFactory;
+import bdv.ui.appearance.AppearanceManager;
+import bdv.ui.keymap.KeymapManager;
 import bdv.viewer.render.AccumulateProjectorARGB;
 import org.scijava.ui.behaviour.io.InputTriggerConfig;
 
@@ -149,12 +151,44 @@ public class BdvOptions
 
 	/**
 	 * Set the {@link InputTriggerConfig} from which keyboard and mouse action mapping is loaded.
+	 * <p>
+	 * Note that this will override the managed {@code InputTriggerConfig}, that is,
+	 * modifying the keymap through the preferences dialog will have no effect.
 	 *
 	 * @param c the {@link InputTriggerConfig} from which keyboard and mouse action mapping is loaded
 	 */
 	public BdvOptions inputTriggerConfig( final InputTriggerConfig c )
 	{
 		values.inputTriggerConfig = c;
+		return this;
+	}
+
+	/**
+	 * Set the {@link KeymapManager} to share keymap settings with other
+	 * BigDataViewer windows.
+	 * <p>
+	 * This can be used to link multiple BigDataViewer windows such that they
+	 * use (and modify) the same {@code Keymap}, shortcuts and mouse gestures.
+	 * </p>
+	 */
+	public BdvOptions keymapManager( final KeymapManager keymapManager )
+	{
+		values.keymapManager = keymapManager;
+		return this;
+	}
+
+	/**
+	 * Set the {@link AppearanceManager} to share appearance settings with other
+	 * BigDataViewer windows.
+	 * <p>
+	 * This can be used to link multiple BigDataViewer windows such that they
+	 * use (and modify) the same {@code Appearance} settings, e.g., LookAndFeel,
+	 * scalebar overlay settings, etc.
+	 * </p>
+	 */
+	public BdvOptions appearanceManager( final AppearanceManager appearanceManager )
+	{
+		values.appearanceManager = appearanceManager;
 		return this;
 	}
 
@@ -266,6 +300,10 @@ public class BdvOptions
 
 		private InputTriggerConfig inputTriggerConfig = null;
 
+		private KeymapManager keymapManager = null;
+
+		private AppearanceManager appearanceManager = null;
+
 		private final AffineTransform3D sourceTransform = new AffineTransform3D();
 
 		private String frameTitle = "BigDataViewer";
@@ -292,6 +330,8 @@ public class BdvOptions
 					.transformEventHandlerFactory( transformEventHandlerFactory )
 					.accumulateProjectorFactory( accumulateProjectorFactory )
 					.inputTriggerConfig( inputTriggerConfig )
+					.keymapManager( keymapManager )
+					.appearanceManager( appearanceManager )
 					.sourceTransform( sourceTransform )
 					.frameTitle( frameTitle )
 					.axisOrder( axisOrder )
@@ -311,7 +351,9 @@ public class BdvOptions
 					.is2D( is2D )
 					.transformEventHandlerFactory( transformEventHandlerFactory )
 					.accumulateProjectorFactory( accumulateProjectorFactory )
-					.inputTriggerConfig( inputTriggerConfig );
+					.inputTriggerConfig( inputTriggerConfig )
+					.keymapManager( keymapManager )
+					.appearanceManager( appearanceManager );
 			if ( hasPreferredSize() )
 				o.width( width ).height( height );
 			return o;
@@ -345,6 +387,16 @@ public class BdvOptions
 		public InputTriggerConfig getInputTriggerConfig()
 		{
 			return inputTriggerConfig;
+		}
+
+		public KeymapManager getKeymapManager()
+		{
+			return keymapManager;
+		}
+
+		public AppearanceManager getAppearanceManager()
+		{
+			return appearanceManager;
 		}
 
 		public Bdv addTo()

--- a/src/main/java/bdv/util/RandomAccessibleIntervalMipmapSource.java
+++ b/src/main/java/bdv/util/RandomAccessibleIntervalMipmapSource.java
@@ -30,7 +30,7 @@ package bdv.util;
 
 import java.util.function.Supplier;
 
-import bdv.util.volatiles.SharedQueue;
+import bdv.cache.SharedQueue;
 import bdv.util.volatiles.VolatileTypeMatcher;
 import mpicbg.spim.data.sequence.VoxelDimensions;
 import net.imglib2.RandomAccessibleInterval;

--- a/src/main/java/bdv/util/VolatileRandomAccessibleIntervalMipmapSource.java
+++ b/src/main/java/bdv/util/VolatileRandomAccessibleIntervalMipmapSource.java
@@ -30,7 +30,7 @@ package bdv.util;
 
 import java.util.function.Supplier;
 
-import bdv.util.volatiles.SharedQueue;
+import bdv.cache.SharedQueue;
 import bdv.util.volatiles.VolatileViews;
 import mpicbg.spim.data.sequence.VoxelDimensions;
 import net.imglib2.RandomAccessibleInterval;

--- a/src/main/java/bdv/util/volatiles/SharedQueue.java
+++ b/src/main/java/bdv/util/volatiles/SharedQueue.java
@@ -28,41 +28,21 @@
  */
 package bdv.util.volatiles;
 
-import java.util.concurrent.Callable;
-
-import bdv.cache.CacheControl;
-import net.imglib2.cache.queue.BlockingFetchQueues;
-import net.imglib2.cache.queue.FetcherThreads;
-
 /**
- * Queue and threads for asynchronously loading data into a cache
- *
- * @author Tobias Pietzsch
+ * @deprecated This class lives now in bigdataviewer-core. Use {@code bdv.cache.SharedQueue} instead.
  */
-public class SharedQueue extends BlockingFetchQueues< Callable< ? > > implements CacheControl
+@Deprecated
+public class SharedQueue extends bdv.cache.SharedQueue
 {
-	private final FetcherThreads fetcherThreads;
-
+	@Deprecated
 	public SharedQueue( final int numFetcherThreads, final int numPriorities )
 	{
-		super( numPriorities, numFetcherThreads );
-		fetcherThreads = new FetcherThreads( this, numFetcherThreads );
+		super( numFetcherThreads, numPriorities );
 	}
 
+	@Deprecated
 	public SharedQueue( final int numFetcherThreads )
 	{
-		this( numFetcherThreads, 1 );
-	}
-
-	public void shutdown()
-	{
-		fetcherThreads.shutdown();
-		clear();
-	}
-
-	@Override
-	public void prepareNextFrame()
-	{
-		clearToPrefetch();
+		super( numFetcherThreads, 1 );
 	}
 }

--- a/src/main/java/bdv/util/volatiles/VolatileViews.java
+++ b/src/main/java/bdv/util/volatiles/VolatileViews.java
@@ -52,6 +52,7 @@ import net.imglib2.type.NativeType;
 import net.imglib2.view.IntervalView;
 import net.imglib2.view.MixedTransformView;
 
+import bdv.cache.SharedQueue;
 import bdv.img.cache.CreateInvalidVolatileCell;
 import bdv.img.cache.VolatileCachedCellImg;
 

--- a/src/test/java/bdv/util/ExampleSharedKeymaps.java
+++ b/src/test/java/bdv/util/ExampleSharedKeymaps.java
@@ -1,0 +1,55 @@
+/*-
+ * #%L
+ * BigDataViewer quick visualization API.
+ * %%
+ * Copyright (C) 2016 - 2021 BigDataViewer developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package bdv.util;
+
+import java.util.Random;
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.basictypeaccess.array.IntArray;
+import net.imglib2.type.numeric.ARGBType;
+
+public class ExampleSharedKeymaps
+{
+	public static void main( final String[] args )
+	{
+		System.setProperty( "apple.laf.useScreenMenuBar", "true" );
+
+		final Random random = new Random();
+
+		final ArrayImg< ARGBType, IntArray > img = ArrayImgs.argbs( 100, 100, 100 );
+		img.forEach( t -> t.set( random.nextInt() & 0xFF00FF00 ) );
+		final BdvHandle bdv = BdvFunctions.show( img, "greens" ).getBdvHandle();
+
+		final ArrayImg< ARGBType, IntArray > img2 = ArrayImgs.argbs( 100, 100, 100 );
+		img2.forEach( t -> t.set( random.nextInt() & 0xFFFF0000 ) );
+		BdvFunctions.show( img2, "reds", Bdv.options()
+				.keymapManager( bdv.getKeymapManager() )
+				.appearanceManager( bdv.getAppearanceManager() ) );
+	}
+}

--- a/src/test/java/bdv/util/ManySourcesExample.java
+++ b/src/test/java/bdv/util/ManySourcesExample.java
@@ -1,0 +1,86 @@
+package bdv.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.type.numeric.ARGBType;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+
+public class ManySourcesExample
+{
+	private static Bdv addSource(final Bdv bdv, final Random random, final int i, final Img< UnsignedByteType > img, final int xOffset, final int yOffset) {
+		AffineTransform3D transform = new AffineTransform3D();
+		transform.translate( xOffset, yOffset, 0 );
+		final BdvSource source = BdvFunctions.show( img, "img " + i,
+				Bdv.options()
+						.addTo( bdv )
+						.preferredSize( 900, 900 )
+						.numRenderingThreads( Runtime.getRuntime().availableProcessors() )
+						.sourceTransform( transform ) );
+		final ARGBType color = new ARGBType( random.nextInt() & 0xFFFFFF );
+		source.setColor( color );
+		return bdv == null ? source : bdv;
+	}
+
+	private static Img< UnsignedByteType > createImg( final Random random )
+	{
+		final long[] dim = { 100, 100, 100 };
+		final Img< UnsignedByteType > img = ArrayImgs.unsignedBytes( dim );
+		img.forEach( t -> t.set( 64 + random.nextInt( 128 ) ) );
+		return img;
+	}
+
+	public static void main( String[] args )
+	{
+		System.setProperty( "apple.laf.useScreenMenuBar", "true" );
+
+		final int[] numSources = { 5, 5 };
+		final Random random = new Random( 1L );
+
+		final List< Img< UnsignedByteType > > imgs = new ArrayList<>();
+		for ( int i = 0; i < numSources[ 0 ] * numSources[ 1 ]; i++ )
+			imgs.add( createImg( random ) );
+
+		int i = 0;
+		Bdv bdv = null;
+		for ( int y = 0; y < numSources[ 1 ]; ++y )
+		{
+			for ( int x = 0; x < numSources[ 0 ]; ++x )
+			{
+				final int xOffset = 90 * x;
+				final int yOffset = 90 * y;
+				bdv = addSource( bdv, random, i, imgs.get( i ), xOffset, yOffset );
+				i++;
+			}
+		}
+
+//		final ViewerPanel viewer = bdv.getBdvHandle().getViewerPanel();
+//		final DebugTilingOverlay tilingOverlay = viewer.showDebugTileOverlay();
+//		final Runnable toggleShowTiles = () -> {
+//			tilingOverlay.setShowTiles( !tilingOverlay.getShowTiles() );
+//			viewer.getDisplay().repaint();
+//		};
+//
+//
+//		final InputTriggerConfig keyconf = viewer.getInputTriggerConfig();
+//		Actions actions = new Actions( keyconf );
+//		actions.install( bdv.getBdvHandle().getKeybindings(), "tile overlay" );
+//		actions.runnableAction( toggleShowTiles, "toggle draw tiles", "T" );
+
+//		// print current transform
+//		viewer.state().changeListeners().add( change -> {
+//			if ( change == ViewerStateChange.VIEWER_TRANSFORM_CHANGED )
+//			{
+//				final AffineTransform3D t = viewer.state().getViewerTransform();
+//				System.out.println( "t = " + Arrays.toString( t.getRowPackedCopy() ) );
+//			}
+//		} );
+
+	}
+
+
+
+}

--- a/src/test/java/bdv/util/benchmark/Rendering25SourcesBenchmark.java
+++ b/src/test/java/bdv/util/benchmark/Rendering25SourcesBenchmark.java
@@ -1,0 +1,99 @@
+package bdv.util.benchmark;
+
+import bdv.util.benchmark.RenderingSetup.Renderer;
+import bdv.viewer.BasicViewerState;
+import bdv.viewer.SourceAndConverter;
+import bdv.viewer.ViewerState;
+import java.io.IOException;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+import static bdv.util.benchmark.RenderingSetup.createSourceAndConverter;
+import static bdv.viewer.DisplayMode.FUSED;
+
+@State( Scope.Thread )
+@Fork( 1 )
+public class Rendering25SourcesBenchmark
+{
+	public ViewerState state;
+	public Renderer renderer;
+
+	@Param({"1", "8"})
+	public int numRenderingThreads;
+
+	@Setup
+	public void setup()
+	{
+		final int[] numSources = { 5, 5 };
+		final int[] targetSize = { 1680, 997 };
+		final AffineTransform3D viewerTransform = new AffineTransform3D();
+		viewerTransform.set(
+				3.7078643166510905, -2.055302752278437, 0.0, 512.6446071237642,
+				2.055302752278437, 3.7078643166510905, 0.0, -912.7996823819342,
+				0.0, 0.0, 4.239401749565353, -208.1315727072766 );
+		final Random random = new Random( 1L );
+
+		state = new BasicViewerState();
+
+		int i = 0;
+		for ( int y = 0; y < numSources[ 1 ]; ++y )
+		{
+			for ( int x = 0; x < numSources[ 0 ]; ++x )
+			{
+				final int xOffset = 90 * x;
+				final int yOffset = 90 * y;
+				final SourceAndConverter< UnsignedByteType > soc = createSourceAndConverter( random, i, xOffset, yOffset );
+				state.addSource( soc );
+				state.setSourceActive( soc, true );
+				i++;
+			}
+		}
+
+		state.setDisplayMode( FUSED );
+		state.setViewerTransform( viewerTransform );
+
+		renderer = new Renderer( targetSize, numRenderingThreads );
+	}
+
+	@Benchmark
+	@BenchmarkMode( Mode.AverageTime )
+	@OutputTimeUnit( TimeUnit.MILLISECONDS )
+	public void bench()
+	{
+		renderer.render( state );
+	}
+
+	public static void main( final String... args ) throws RunnerException, IOException
+	{
+		final Options opt = new OptionsBuilder()
+				.include( Rendering25SourcesBenchmark.class.getSimpleName() )
+				.warmupIterations( 4 )
+				.measurementIterations( 8 )
+				.warmupTime( TimeValue.milliseconds( 500 ) )
+				.measurementTime( TimeValue.milliseconds( 500 ) )
+				.build();
+		new Runner( opt ).run();
+
+//		final Rendering25SourcesBenchmark b = new Rendering25SourcesBenchmark();
+//		b.numRenderingThreads = 1;
+//		b.setup();
+//		b.bench();
+//		b.renderer.writeResult( "/Users/pietzsch/Desktop/Rendering25SourcesBenchmark.png" );
+	}
+}

--- a/src/test/java/bdv/util/benchmark/RenderingSetup.java
+++ b/src/test/java/bdv/util/benchmark/RenderingSetup.java
@@ -1,0 +1,143 @@
+package bdv.util.benchmark;
+
+import bdv.BigDataViewer;
+import bdv.cache.CacheControl;
+import bdv.tools.brightness.ConverterSetup;
+import bdv.util.RandomAccessibleIntervalSource;
+import bdv.viewer.Source;
+import bdv.viewer.SourceAndConverter;
+import bdv.viewer.ViewerState;
+import bdv.viewer.render.AccumulateProjectorARGB;
+import bdv.viewer.render.AccumulateProjectorFactory;
+import bdv.viewer.render.MultiResolutionRenderer;
+import bdv.viewer.render.RenderTarget;
+import bdv.viewer.render.awt.BufferedImageRenderResult;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.util.Random;
+import javax.imageio.ImageIO;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.type.numeric.ARGBType;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+
+public class RenderingSetup
+{
+	private static Img< UnsignedByteType > createImg()
+	{
+		return createImg( new Random(), 100, 100, 100 );
+	}
+
+	private static Img< UnsignedByteType > createImg( final Random random, final long... dims )
+	{
+		final Img< UnsignedByteType > img = ArrayImgs.unsignedBytes( dims );
+		img.forEach( t -> t.set( 64 + random.nextInt( 128 ) ) );
+		return img;
+	}
+
+
+	private static Source< UnsignedByteType > createSource(
+			final Random random,
+			final int i,
+			final int xOffset,
+			final int yOffset )
+	{
+		final AffineTransform3D sourceTransform = new AffineTransform3D();
+		sourceTransform.translate( xOffset, yOffset, 0 );
+		final String name = "img " + i;
+		final Img< UnsignedByteType > img = createImg( random, 100, 100, 100 );
+		Source< UnsignedByteType > source = new RandomAccessibleIntervalSource( img, new UnsignedByteType(), sourceTransform, name );
+		return source;
+	}
+
+	public static SourceAndConverter< UnsignedByteType > createSourceAndConverter(
+			final Random random,
+			final int i,
+			final int xOffset,
+			final int yOffset )
+	{
+		final Source< UnsignedByteType > source = createSource( random, i, xOffset, yOffset );
+		final SourceAndConverter< UnsignedByteType > soc = BigDataViewer.wrapWithTransformedSource(
+				new SourceAndConverter<>( source, BigDataViewer.createConverterToARGB( source.getType() ) ) );
+		final ConverterSetup converterSetup = BigDataViewer.createConverterSetup( soc, 0 );
+		final ARGBType color = new ARGBType( random.nextInt() & 0xFFFFFF );
+		converterSetup.setColor( color );
+		return soc;
+	}
+
+	public static class BenchmarkRenderTarget implements RenderTarget< BufferedImageRenderResult >
+	{
+		private final int width;
+		private final int height;
+		private final BufferedImageRenderResult renderResult = new BufferedImageRenderResult();
+
+		public BenchmarkRenderTarget( final int width, final int height )
+		{
+			this.width = width;
+			this.height = height;
+		}
+
+		@Override
+		public BufferedImageRenderResult getReusableRenderResult()
+		{
+			return renderResult;
+		}
+
+		@Override
+		public BufferedImageRenderResult createRenderResult()
+		{
+			return new BufferedImageRenderResult();
+		}
+
+		@Override
+		public void setRenderResult( final BufferedImageRenderResult renderResult )
+		{}
+
+		@Override
+		public int getWidth()
+		{
+			return width;
+		}
+
+		@Override
+		public int getHeight()
+		{
+			return height;
+		}
+
+		public BufferedImageRenderResult getRenderResult()
+		{
+			return renderResult;
+		}
+	}
+
+	public static class Renderer
+	{
+		private final BenchmarkRenderTarget target;
+		private final MultiResolutionRenderer renderer;
+
+		public Renderer(final int[] targetSize, final int numRenderingThreads)
+		{
+			target = new BenchmarkRenderTarget( targetSize[ 0 ], targetSize[ 1 ] );
+			final AccumulateProjectorFactory< ARGBType > accumulateProjectorFactory = AccumulateProjectorARGB.factory;
+			renderer = new MultiResolutionRenderer(
+					target, () -> {}, new double[] { 1 }, 0,
+					numRenderingThreads, null, false,
+					accumulateProjectorFactory, new CacheControl.Dummy() );
+		}
+
+		public void render( final ViewerState state )
+		{
+			renderer.requestRepaint();
+			renderer.paint( state );
+		}
+
+		public void writeResult( final String filename ) throws IOException
+		{
+			final BufferedImage bi = target.getRenderResult().getBufferedImage();
+			ImageIO.write( bi, "png", new File( filename ) );
+		}
+	}
+}

--- a/src/test/java/bdv/util/benchmark/RenderingSingleSourceBenchmark.java
+++ b/src/test/java/bdv/util/benchmark/RenderingSingleSourceBenchmark.java
@@ -1,0 +1,89 @@
+package bdv.util.benchmark;
+
+import bdv.util.benchmark.RenderingSetup.Renderer;
+import bdv.viewer.BasicViewerState;
+import bdv.viewer.SourceAndConverter;
+import bdv.viewer.ViewerState;
+import java.io.IOException;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+import static bdv.util.benchmark.RenderingSetup.createSourceAndConverter;
+
+@State( Scope.Thread )
+@Fork( 1 )
+public class RenderingSingleSourceBenchmark
+{
+	public ViewerState state;
+	public Renderer renderer;
+
+	@Param({"1", "8"})
+	public int numRenderingThreads;
+
+	@Setup
+	public void setup()
+	{
+		final int[] targetSize = { 1680, 997 };
+		final AffineTransform3D viewerTransform = new AffineTransform3D();
+		viewerTransform.set(
+				23.01374483164624, -2.19266950637996, -26.415703464229598, 1275.9089927440664,
+				12.592003473417137, 31.68776756743586, 8.340052479934124, -1790.2640725526244,
+				23.324635851386212, -14.943467712629362, 21.561163590406633, -1046.864337123486 );
+
+
+		final Random random = new Random( 1L );
+
+		state = new BasicViewerState();
+		final SourceAndConverter< UnsignedByteType > soc = createSourceAndConverter( random, 0, 0, 0 );
+		state.addSource( soc );
+		state.setSourceActive( soc, true );
+		state.setViewerTransform( viewerTransform );
+
+//		final int numRenderingThreads = 1;
+//		final int numRenderingThreads = Runtime.getRuntime().availableProcessors();
+//		System.out.println( "numRenderingThreads = " + numRenderingThreads );
+		renderer = new Renderer( targetSize, numRenderingThreads );
+	}
+
+	@Benchmark
+	@BenchmarkMode( Mode.AverageTime )
+	@OutputTimeUnit( TimeUnit.MILLISECONDS )
+	public void bench()
+	{
+		renderer.render( state );
+	}
+
+	public static void main( final String... args ) throws RunnerException, IOException
+	{
+		final Options opt = new OptionsBuilder()
+				.include( RenderingSingleSourceBenchmark.class.getSimpleName() )
+				.warmupIterations( 4 )
+				.measurementIterations( 8 )
+				.warmupTime( TimeValue.milliseconds( 500 ) )
+				.measurementTime( TimeValue.milliseconds( 500 ) )
+				.build();
+		new Runner( opt ).run();
+
+//		final RenderingSingleSourceBenchmark b = new RenderingSingleSourceBenchmark();
+//		b.numRenderingThreads = 1;
+//		b.setup();
+//		b.bench();
+//		b.renderer.writeResult( "/Users/pietzsch/Desktop/RenderingSingleSourceBenchmark.png" );
+	}
+}

--- a/src/test/java/bdv/util/benchmark/RenderingWithEmptyBenchmark.java
+++ b/src/test/java/bdv/util/benchmark/RenderingWithEmptyBenchmark.java
@@ -1,0 +1,95 @@
+package bdv.util.benchmark;
+
+import bdv.util.benchmark.RenderingSetup.Renderer;
+import bdv.viewer.BasicViewerState;
+import bdv.viewer.DisplayMode;
+import bdv.viewer.SourceAndConverter;
+import bdv.viewer.ViewerState;
+import java.io.IOException;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+import static bdv.util.benchmark.RenderingSetup.createSourceAndConverter;
+import static bdv.viewer.DisplayMode.FUSED;
+
+@State( Scope.Thread )
+@Fork( 1 )
+public class RenderingWithEmptyBenchmark
+{
+	public ViewerState state;
+	public Renderer renderer;
+
+	@Param({"1", "8"})
+	public int numRenderingThreads;
+
+	@Setup
+	public void setup()
+	{
+		final int[] targetSize = { 1680, 997 };
+		final AffineTransform3D viewerTransform = new AffineTransform3D();
+		viewerTransform.set(
+				6.085785957730029, -1.8606114880683469, 0.0, 706.509797402479,
+				1.8606114880683469, 6.085785957730029, 0.0, 35.890787275681475,
+				0.0, 0.0, 6.36385620774353, -318.02826989221813 );
+
+		final Random random = new Random( 1L );
+
+		state = new BasicViewerState();
+		{
+			final SourceAndConverter< UnsignedByteType > soc = createSourceAndConverter( random, 0, 0, 0 );
+			state.addSource( soc );
+			state.setSourceActive( soc, true );
+		}
+		{
+			final SourceAndConverter< UnsignedByteType > soc = createSourceAndConverter( random, 1, 90, 0 );
+			state.addSource( soc );
+			state.setSourceActive( soc, true );
+		}
+		state.setDisplayMode( FUSED );
+		state.setViewerTransform( viewerTransform );
+
+		renderer = new Renderer( targetSize, numRenderingThreads );
+	}
+
+	@Benchmark
+	@BenchmarkMode( Mode.AverageTime )
+	@OutputTimeUnit( TimeUnit.MILLISECONDS )
+	public void bench()
+	{
+		renderer.render( state );
+	}
+
+	public static void main( final String... args ) throws RunnerException, IOException
+	{
+		final Options opt = new OptionsBuilder()
+				.include( RenderingWithEmptyBenchmark.class.getSimpleName() )
+				.warmupIterations( 4 )
+				.measurementIterations( 8 )
+				.warmupTime( TimeValue.milliseconds( 500 ) )
+				.measurementTime( TimeValue.milliseconds( 500 ) )
+				.build();
+		new Runner( opt ).run();
+
+//		final RenderingWithEmptyBenchmark b = new RenderingWithEmptyBenchmark();
+//		b.numRenderingThreads = 1;
+//		b.setup();
+//		b.bench();
+//		b.renderer.writeResult( "/Users/pietzsch/Desktop/RenderingWithEmptyBenchmark.png" );
+	}
+}


### PR DESCRIPTION
Tracks changes from bdv-core 10.2.1 to 10.4.1:
* Add examples and benchmarks for tiled renderer
* Deprecate SharedQueue (moved to bdv-core)
* Expose getters and options for sharing KeymapManager and AppearanceManager