### PR TITLE
Create empty BDV window

### DIFF
--- a/src/main/java/bdv/util/BdvFunctions.java
+++ b/src/main/java/bdv/util/BdvFunctions.java
@@ -83,6 +83,20 @@ import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
  */
 public class BdvFunctions
 {
+	public static BdvHandle show()
+	{
+		return show( Bdv.options() );
+	}
+
+	public static BdvHandle show(
+			final BdvOptions options )
+	{
+		final BdvHandle handle = getHandle( options );
+		if ( handle instanceof BdvHandleFrame && ( ( BdvHandleFrame ) handle ).getBigDataViewer() == null )
+			handle.createViewer( Collections.emptyList(), Collections.emptyList(), 1 );
+		return handle;
+	}
+
 	public static < T > BdvStackSource< T > show(
 			final RandomAccessibleInterval< T > img,
 			final String name )

--- a/src/main/java/bdv/util/BdvOverlaySource.java
+++ b/src/main/java/bdv/util/BdvOverlaySource.java
@@ -78,7 +78,6 @@ public class BdvOverlaySource< O extends OverlayRenderer > extends BdvSource
 				Collections.singletonList( info ),
 				Collections.singletonList( overlay ) );
 		getBdvHandle().removeBdvSource( this );
-		setBdvHandle( null );
 	}
 
 	@Override

--- a/src/main/java/bdv/util/BdvStackSource.java
+++ b/src/main/java/bdv/util/BdvStackSource.java
@@ -65,7 +65,6 @@ public class BdvStackSource< T > extends BdvSource
 	{
 		getBdvHandle().remove( converterSetups, sources, null, null, null, null );
 		getBdvHandle().removeBdvSource( this );
-		setBdvHandle( null );
 	}
 
 	@Override

--- a/src/main/java/bdv/util/BdvVirtualChannelSource.java
+++ b/src/main/java/bdv/util/BdvVirtualChannelSource.java
@@ -77,7 +77,6 @@ public class BdvVirtualChannelSource extends BdvSource
 				Collections.singletonList( info ),
 				null );
 		getBdvHandle().removeBdvSource( this );
-		setBdvHandle( null );
 	}
 
 	@Override

--- a/src/test/java/bdv/util/ExampleOpenEmpty.java
+++ b/src/test/java/bdv/util/ExampleOpenEmpty.java
@@ -1,0 +1,39 @@
+/*-
+ * #%L
+ * BigDataViewer quick visualization API.
+ * %%
+ * Copyright (C) 2016 - 2023 BigDataViewer developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package bdv.util;
+
+public class ExampleOpenEmpty
+{
+	public static void main( final String[] args )
+	{
+		System.setProperty( "apple.laf.useScreenMenuBar", "true" );
+//		Bdv bdv = BdvFunctions.show();
+		Bdv bdv = BdvFunctions.show( Bdv.options().frameTitle( "empty bdv window" ).is2D() );
+	}
+}


### PR DESCRIPTION
Adds two new methods to `BdvFunctions`:

`BdvFunctions.show()` opens an empty BDV window.
`BdfFunctions.show(Bdv.options()...)` opens an empty BDV window with additional configuration, like window size, title, etc...