### PR TITLE
Add RandomAccessibleIntervalMipmapSource4D, VolatileSource

### DIFF
--- a/src/main/java/bdv/util/RandomAccessibleIntervalMipmapSource.java
+++ b/src/main/java/bdv/util/RandomAccessibleIntervalMipmapSource.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -46,6 +46,22 @@ public class RandomAccessibleIntervalMipmapSource< T extends NumericType< T > > 
 	protected final AffineTransform3D[] mipmapTransforms;
 
 	protected final VoxelDimensions voxelDimensions;
+
+	public RandomAccessibleIntervalMipmapSource(
+			final RandomAccessibleInterval< T >[] imgs,
+			final T type,
+			final AffineTransform3D[] mipmapTransforms,
+			final VoxelDimensions voxelDimensions,
+			final String name,
+			final boolean doBoundingBoxCulling )
+	{
+		super( type, name, doBoundingBoxCulling );
+		assert imgs.length == mipmapTransforms.length : "Number of mipmaps and scale factors do not match.";
+
+		this.mipmapSources = imgs;
+		this.mipmapTransforms = mipmapTransforms;
+		this.voxelDimensions = voxelDimensions;
+	}
 
 	public RandomAccessibleIntervalMipmapSource(
 			final RandomAccessibleInterval< T >[] imgs,

--- a/src/main/java/bdv/util/RandomAccessibleIntervalMipmapSource.java
+++ b/src/main/java/bdv/util/RandomAccessibleIntervalMipmapSource.java
@@ -45,8 +45,6 @@ public class RandomAccessibleIntervalMipmapSource< T extends NumericType< T > > 
 
 	protected final AffineTransform3D[] mipmapTransforms;
 
-	protected final VoxelDimensions voxelDimensions;
-
 	public RandomAccessibleIntervalMipmapSource(
 			final RandomAccessibleInterval< T >[] imgs,
 			final T type,
@@ -55,12 +53,11 @@ public class RandomAccessibleIntervalMipmapSource< T extends NumericType< T > > 
 			final String name,
 			final boolean doBoundingBoxCulling )
 	{
-		super( type, name, doBoundingBoxCulling );
+		super( type, name, voxelDimensions, doBoundingBoxCulling );
 		assert imgs.length == mipmapTransforms.length : "Number of mipmaps and scale factors do not match.";
 
 		this.mipmapSources = imgs;
 		this.mipmapTransforms = mipmapTransforms;
-		this.voxelDimensions = voxelDimensions;
 	}
 
 	public RandomAccessibleIntervalMipmapSource(
@@ -72,7 +69,7 @@ public class RandomAccessibleIntervalMipmapSource< T extends NumericType< T > > 
 			final String name,
 			final boolean doBoundingBoxCulling )
 	{
-		super( type, name, doBoundingBoxCulling );
+		super( type, name, voxelDimensions, doBoundingBoxCulling );
 		assert imgs.length == mipmapScales.length : "Number of mipmaps and scale factors do not match.";
 
 		this.mipmapSources = imgs;
@@ -87,8 +84,6 @@ public class RandomAccessibleIntervalMipmapSource< T extends NumericType< T > > 
 			mipmapTransform.preConcatenate(sourceTransform);
 			mipmapTransforms[ s ] = mipmapTransform;
 		}
-
-		this.voxelDimensions = voxelDimensions;
 	}
 
 	public RandomAccessibleIntervalMipmapSource(

--- a/src/main/java/bdv/util/RandomAccessibleIntervalMipmapSource.java
+++ b/src/main/java/bdv/util/RandomAccessibleIntervalMipmapSource.java
@@ -120,12 +120,6 @@ public class RandomAccessibleIntervalMipmapSource< T extends NumericType< T > > 
 	}
 
 	@Override
-	public VoxelDimensions getVoxelDimensions()
-	{
-		return voxelDimensions;
-	}
-
-	@Override
 	public int getNumMipmapLevels()
 	{
 		return mipmapSources.length;

--- a/src/main/java/bdv/util/RandomAccessibleIntervalMipmapSource4D.java
+++ b/src/main/java/bdv/util/RandomAccessibleIntervalMipmapSource4D.java
@@ -199,12 +199,6 @@ public class RandomAccessibleIntervalMipmapSource4D< T extends NumericType< T > 
 	}
 
 	@Override
-	public VoxelDimensions getVoxelDimensions()
-	{
-		return voxelDimensions;
-	}
-
-	@Override
 	public int getNumMipmapLevels()
 	{
 		return mipmapSources.length;

--- a/src/main/java/bdv/util/RandomAccessibleIntervalMipmapSource4D.java
+++ b/src/main/java/bdv/util/RandomAccessibleIntervalMipmapSource4D.java
@@ -83,7 +83,7 @@ public class RandomAccessibleIntervalMipmapSource4D< T extends NumericType< T > 
 		assert assertAllTDimensionsEqual(imgs) : "Mipmaps have different numbers of timepoints.";
 
 		this.mipmapSources = imgs;
-		currentMipmaps = new RandomAccessibleInterval[imgs.length];
+		currentMipmaps = new RandomAccessibleInterval[ imgs.length ];
 		this.mipmapTransforms = mipmapTransforms;
 
 		minT = mipmapSources[0].min(3);
@@ -107,7 +107,7 @@ public class RandomAccessibleIntervalMipmapSource4D< T extends NumericType< T > 
 		assert assertAllTDimensionsEqual(imgs) : "Mipmaps have different numbers of timepoints.";
 
 		this.mipmapSources = imgs;
-		currentMipmaps = new RandomAccessibleInterval[imgs.length];
+		currentMipmaps = new RandomAccessibleInterval[ imgs.length ];
 		this.mipmapTransforms = new AffineTransform3D[ mipmapScales.length ];
 		for ( int s = 0; s < mipmapScales.length; ++s )
 		{

--- a/src/main/java/bdv/util/RandomAccessibleIntervalMipmapSource4D.java
+++ b/src/main/java/bdv/util/RandomAccessibleIntervalMipmapSource4D.java
@@ -1,0 +1,232 @@
+/*
+ * #%L
+ * BigDataViewer quick visualization API.
+ * %%
+ * Copyright (C) 2016 - 2023 BigDataViewer developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package bdv.util;
+
+import java.util.Arrays;
+import java.util.function.Supplier;
+
+import bdv.cache.SharedQueue;
+import bdv.util.volatiles.VolatileTypeMatcher;
+import bdv.viewer.Interpolation;
+import mpicbg.spim.data.sequence.VoxelDimensions;
+import net.imglib2.Interval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.RealRandomAccessible;
+import net.imglib2.Volatile;
+import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.NumericType;
+import net.imglib2.view.Views;
+
+public class RandomAccessibleIntervalMipmapSource4D< T extends NumericType< T > > extends AbstractSource< T >
+{
+	protected final RandomAccessibleInterval< T >[] mipmapSources;
+
+	protected final long minT, maxT;
+
+	protected int currentTimePointIndex;
+
+	private final RandomAccessibleInterval< T >[] currentMipmaps;
+
+	private final RealRandomAccessible< T >[][] currentInterpolatedSources;
+
+	protected final AffineTransform3D[] mipmapTransforms;
+
+	private static boolean assertAllTDimensionsEqual(final Interval[] intervals) {
+
+		final long min = intervals[0].min(3);
+		final long max = intervals[0].min(3);
+
+		for (int i = 1; i < intervals.length; ++i)
+			if (!(intervals[i].min(3) == min && intervals[i].max(3) == max))
+				return false;
+
+		return true;
+	}
+
+	public RandomAccessibleIntervalMipmapSource4D(
+			final RandomAccessibleInterval< T >[] imgs,
+			final T type,
+			final AffineTransform3D[] mipmapTransforms,
+			final VoxelDimensions voxelDimensions,
+			final String name,
+			final boolean doBoundingBoxCulling )
+	{
+		super( type, name, voxelDimensions, doBoundingBoxCulling );
+		assert imgs.length == mipmapTransforms.length : "Number of mipmaps and scale factors do not match.";
+		assert assertAllTDimensionsEqual(imgs) : "Mipmaps have different numbers of timepoints.";
+
+		this.mipmapSources = imgs;
+		currentMipmaps = new RandomAccessibleInterval[imgs.length];
+		this.mipmapTransforms = mipmapTransforms;
+
+		minT = mipmapSources[0].min(3);
+		maxT = mipmapSources[0].max(3);
+
+		currentInterpolatedSources = new RealRandomAccessible[ Interpolation.values().length ][ imgs.length ];
+		loadTimepoint( 0 );
+	}
+
+	public RandomAccessibleIntervalMipmapSource4D(
+			final RandomAccessibleInterval< T >[] imgs,
+			final T type,
+			final double[][] mipmapScales,
+			final VoxelDimensions voxelDimensions,
+			final AffineTransform3D sourceTransform,
+			final String name,
+			final boolean doBoundingBoxCulling )
+	{
+		super( type, name, voxelDimensions, doBoundingBoxCulling );
+		assert imgs.length == mipmapScales.length : "Number of mipmaps and scale factors do not match.";
+		assert assertAllTDimensionsEqual(imgs) : "Mipmaps have different numbers of timepoints.";
+
+		this.mipmapSources = imgs;
+		currentMipmaps = new RandomAccessibleInterval[imgs.length];
+		this.mipmapTransforms = new AffineTransform3D[ mipmapScales.length ];
+		for ( int s = 0; s < mipmapScales.length; ++s )
+		{
+			final AffineTransform3D mipmapTransform = new AffineTransform3D();
+			mipmapTransform.set(
+					mipmapScales[ s ][ 0 ], 0, 0, 0.5 * ( mipmapScales[ s ][ 0 ] - 1 ),
+					0, mipmapScales[ s ][ 1 ], 0, 0.5 * ( mipmapScales[ s ][ 1 ] - 1 ),
+					0, 0, mipmapScales[ s ][ 2 ], 0.5 * ( mipmapScales[ s ][ 2 ] - 1 ) );
+			mipmapTransform.preConcatenate(sourceTransform);
+			mipmapTransforms[ s ] = mipmapTransform;
+		}
+
+		minT = mipmapSources[0].min(3);
+		maxT = mipmapSources[0].max(3);
+
+		currentInterpolatedSources = new RealRandomAccessible[ Interpolation.values().length ][ imgs.length ];
+		loadTimepoint( 0 );
+	}
+
+	public RandomAccessibleIntervalMipmapSource4D(
+			final RandomAccessibleInterval< T >[] imgs,
+			final T type,
+			final double[][] mipmapScales,
+			final VoxelDimensions voxelDimensions,
+			final AffineTransform3D sourceTransform,
+			final String name )
+	{
+		this( imgs, type, mipmapScales, voxelDimensions, sourceTransform, name, true );
+	}
+
+	public RandomAccessibleIntervalMipmapSource4D(
+			final RandomAccessibleInterval< T >[] imgs,
+			final T type,
+			final double[][] mipmapScales,
+			final VoxelDimensions voxelDimensions,
+			final String name )
+	{
+		this(imgs, type, mipmapScales, voxelDimensions, new AffineTransform3D(), name);
+	}
+
+	private void loadTimepoint( final int timepointIndex )
+	{
+		currentTimePointIndex = timepointIndex;
+		if ( isPresent( timepointIndex ) )
+		{
+			final T zero = getType().createVariable();
+			zero.setZero();
+			for ( int level = 0; level < currentMipmaps.length; ++level )
+			{
+				currentMipmaps[level] = Views.hyperSlice(mipmapSources[level], 3, timepointIndex );
+				for ( final Interpolation method : Interpolation.values() )
+					currentInterpolatedSources[ method.ordinal() ][ level ] =
+							Views.interpolate( Views.extendValue( currentMipmaps[level], zero ), interpolators.get( method ) );
+			}
+		}
+		else
+		{
+			Arrays.fill( currentMipmaps, null );
+			Arrays.fill( currentInterpolatedSources, null );
+		}
+	}
+
+	@Override
+	public boolean isPresent( final int t )
+	{
+		return minT <= t && t <= maxT;
+	}
+
+	@Override
+	public RandomAccessibleInterval< T > getSource( final int t, final int level )
+	{
+		if ( t != currentTimePointIndex )
+			loadTimepoint( t );
+		return currentMipmaps[ level ];
+	}
+
+	@Override
+	public RealRandomAccessible< T > getInterpolatedSource( final int t, final int level, final Interpolation method )
+	{
+		if ( t != currentTimePointIndex )
+			loadTimepoint( t );
+		return currentInterpolatedSources[ method.ordinal() ][ level ];
+	}
+
+	@Override
+	public synchronized void getSourceTransform( final int t, final int level, final AffineTransform3D transform )
+	{
+		transform.set( mipmapTransforms[ level ] );
+	}
+
+	@Override
+	public VoxelDimensions getVoxelDimensions()
+	{
+		return voxelDimensions;
+	}
+
+	@Override
+	public int getNumMipmapLevels()
+	{
+		return mipmapSources.length;
+	}
+
+	public < V extends Volatile< T > & NumericType< V > > VolatileSource< T, V > asVolatile( final V vType, final SharedQueue queue )
+	{
+		return new VolatileSource<>( this, vType, queue );
+	}
+
+	public < V extends Volatile< T > & NumericType< V > > VolatileSource< T, V > asVolatile( final Supplier< V > vTypeSupplier, final SharedQueue queue )
+	{
+		return new VolatileSource<>( this, vTypeSupplier, queue );
+	}
+
+	@SuppressWarnings( { "unchecked", "rawtypes" } )
+	public < V extends Volatile< T > & NumericType< V > > VolatileSource< T, V > asVolatile( final SharedQueue queue )
+	{
+		final T t = getType();
+		if ( t instanceof NativeType )
+			return new VolatileSource<>( this, ( V )VolatileTypeMatcher.getVolatileTypeForType( ( NativeType )getType() ), queue );
+		else
+			throw new UnsupportedOperationException( "This method only works for sources of NativeType." );
+	}
+}

--- a/src/main/java/bdv/util/VolatileSource.java
+++ b/src/main/java/bdv/util/VolatileSource.java
@@ -31,28 +31,61 @@ package bdv.util;
 import java.util.function.Supplier;
 
 import bdv.cache.SharedQueue;
+import bdv.util.volatiles.VolatileViews;
+import bdv.viewer.Source;
+import mpicbg.spim.data.sequence.VoxelDimensions;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.Volatile;
+import net.imglib2.cache.volatiles.CacheHints;
+import net.imglib2.cache.volatiles.LoadingStrategy;
+import net.imglib2.realtransform.AffineTransform3D;
 import net.imglib2.type.numeric.NumericType;
 
-/**
- * @deprecated use {@code VolatileSource}
- */
-@Deprecated
-public class VolatileRandomAccessibleIntervalMipmapSource< T extends NumericType< T >, V extends Volatile< T > & NumericType< V > > extends VolatileSource< T, V >
+public class VolatileSource< T extends NumericType< T >, V extends Volatile< T > & NumericType< V > > extends AbstractSource< V >
 {
-	public VolatileRandomAccessibleIntervalMipmapSource(
-			final RandomAccessibleIntervalMipmapSource< T > source,
+	private final Source< T > source;
+
+	private SharedQueue queue;
+
+	public VolatileSource(
+			final Source< T > source,
 			final V type,
 			final SharedQueue queue )
 	{
-		super( source, type, queue );
+		super( type, source.getName() );
+		this.source = source;
+		this.queue = queue;
 	}
 
-	public VolatileRandomAccessibleIntervalMipmapSource(
-			final RandomAccessibleIntervalMipmapSource< T > source,
+	public VolatileSource(
+			final Source< T > source,
 			final Supplier< V > typeSupplier,
 			final SharedQueue queue )
 	{
-		super( source, typeSupplier, queue );
+		this( source, typeSupplier.get(), queue );
+	}
+
+	@Override
+	public RandomAccessibleInterval< V > getSource( final int t, final int level )
+	{
+		return VolatileViews.wrapAsVolatile( source.getSource( t, level ), queue, new CacheHints( LoadingStrategy.VOLATILE, level, true ) );
+	}
+
+	@Override
+	public synchronized void getSourceTransform( final int t, final int level, final AffineTransform3D transform )
+	{
+		source.getSourceTransform( t, level, transform );
+	}
+
+	@Override
+	public VoxelDimensions getVoxelDimensions()
+	{
+		return source.getVoxelDimensions();
+	}
+
+	@Override
+	public int getNumMipmapLevels()
+	{
+		return source.getNumMipmapLevels();
 	}
 }

--- a/src/test/java/bdv/util/ExampleMipmapSource4D.java
+++ b/src/test/java/bdv/util/ExampleMipmapSource4D.java
@@ -48,19 +48,19 @@ public class ExampleMipmapSource4D
 {
 	public static void main( String[] args )
 	{
-		final BiConsumer<Localizable, DoubleType> f = (p, v) -> {
+		final BiConsumer< Localizable, DoubleType > f = ( p, v ) -> {
 
-			final double xc = p.getDoublePosition(0) - 100;
-			final double yc = p.getDoublePosition(1) - 100;
-			final double zc = p.getDoublePosition(2) - 100;
-			final double t  = p.getDoublePosition(3);
-			final double s = 20 + (20*t);
-			v.set( Math.sqrt(xc * xc / 2 + yc * yc / 16 + zc * zc / 64) / s );
+			final double xc = p.getDoublePosition( 0 ) - 100;
+			final double yc = p.getDoublePosition( 1 ) - 100;
+			final double zc = p.getDoublePosition( 2 ) - 100;
+			final double t = p.getDoublePosition( 3 );
+			final double s = 20 + ( 20 * t );
+			v.set( Math.sqrt( xc * xc / 2 + yc * yc / 16 + zc * zc / 64 ) / s );
 		};
 
-		final IntervalView<DoubleType> img = Views.interval(
-				new FunctionRandomAccessible<DoubleType>( 4, f, () -> new DoubleType() ),
-				new FinalInterval( 200, 200, 200, 20 ));
+		final IntervalView< DoubleType > img = Views.interval(
+				new FunctionRandomAccessible<>( 4, f, DoubleType::new ),
+				new FinalInterval( 200, 200, 200, 20 ) );
 
 
 		// set to true to make the scale transforms not match the downsampling factors
@@ -68,31 +68,31 @@ public class ExampleMipmapSource4D
 		final boolean scalesTooBig = false;
 
 		final int N = 3;
-		@SuppressWarnings("unchecked")
-		final RandomAccessibleInterval<DoubleType>[] imgs = new RandomAccessibleInterval[N];
-		final AffineTransform3D[] transforms =  new AffineTransform3D[N];
-		for( int i = 0; i < N; i++ )
+		@SuppressWarnings( "unchecked" )
+		final RandomAccessibleInterval< DoubleType >[] imgs = new RandomAccessibleInterval[ N ];
+		final AffineTransform3D[] transforms = new AffineTransform3D[ N ];
+		for ( int i = 0; i < N; i++ )
 		{
-			transforms[i] = new AffineTransform3D();
-			if(scalesTooBig)
-				transforms[i].scale(Math.pow(4, i));
+			transforms[ i ] = new AffineTransform3D();
+			if ( scalesTooBig )
+				transforms[ i ].scale( Math.pow( 4, i ) );
 			else
-				transforms[i].scale(Math.pow(2, i));
+				transforms[ i ].scale( Math.pow( 2, i ) );
 
-			if( i == 0 )
-				imgs[i] = img;
+			if ( i == 0 )
+				imgs[ i ] = img;
 			else
-				imgs[i] = Views.subsample(img, 2*i, 2*i, 2*i, 1);
+				imgs[ i ] = Views.subsample( img, 2 * i, 2 * i, 2 * i, 1 );
 		}
 
-		final RandomAccessibleIntervalMipmapSource4D<DoubleType> raiSource4D = new RandomAccessibleIntervalMipmapSource4D<	>(
+		final RandomAccessibleIntervalMipmapSource4D< DoubleType > raiSource4D = new RandomAccessibleIntervalMipmapSource4D<>(
 				imgs,
-				Util.getTypeFromInterval(img),
+				Util.getTypeFromInterval( img ),
 				transforms,
-				new FinalVoxelDimensions("um", 1, 1, 1 ),
+				new FinalVoxelDimensions( "um", 1, 1, 1 ),
 				"4d rai source", true );
 
-		final BdvStackSource<DoubleType> bdv = BdvFunctions.show( raiSource4D, 5 );
-		bdv.setDisplayRange(0, 3);
+		final BdvStackSource< DoubleType > bdv = BdvFunctions.show( raiSource4D, 5 );
+		bdv.setDisplayRange( 0, 3 );
 	}
 }

--- a/src/test/java/bdv/util/ExampleMipmapSource4D.java
+++ b/src/test/java/bdv/util/ExampleMipmapSource4D.java
@@ -1,0 +1,98 @@
+/*-
+ * #%L * BigDataViewer quick visualization API.
+ * %%
+ * Copyright (C) 2016 - 2023 BigDataViewer developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package bdv.util;
+
+import net.imglib2.FinalInterval;
+import net.imglib2.Localizable;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.position.FunctionRandomAccessible;
+import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.type.numeric.ARGBType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.util.Intervals;
+import net.imglib2.util.Util;
+import net.imglib2.view.IntervalView;
+import net.imglib2.view.Views;
+
+import java.util.function.BiConsumer;
+import java.util.stream.DoubleStream;
+
+import mpicbg.spim.data.sequence.FinalVoxelDimensions;
+
+public class ExampleMipmapSource4D
+{
+	public static void main( String[] args )
+	{
+		final BiConsumer<Localizable, DoubleType> f = (p, v) -> {
+
+			final double xc = p.getDoublePosition(0) - 100;
+			final double yc = p.getDoublePosition(1) - 100;
+			final double zc = p.getDoublePosition(2) - 100;
+			final double t  = p.getDoublePosition(3);
+			final double s = 20 + (20*t);
+			v.set( Math.sqrt(xc * xc / 2 + yc * yc / 16 + zc * zc / 64) / s );
+		};
+
+		final IntervalView<DoubleType> img = Views.interval(
+				new FunctionRandomAccessible<DoubleType>( 4, f, () -> new DoubleType() ),
+				new FinalInterval( 200, 200, 200, 20 ));
+
+
+		// set to true to make the scale transforms not match the downsampling factors
+		// its can be useful to confirm that bdv really sees the multiple scales
+		final boolean scalesTooBig = false;
+
+		final int N = 3;
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<DoubleType>[] imgs = new RandomAccessibleInterval[N];
+		final AffineTransform3D[] transforms =  new AffineTransform3D[N];
+		for( int i = 0; i < N; i++ )
+		{
+			transforms[i] = new AffineTransform3D();
+			if(scalesTooBig)
+				transforms[i].scale(Math.pow(4, i));
+			else
+				transforms[i].scale(Math.pow(2, i));
+
+			if( i == 0 )
+				imgs[i] = img;
+			else
+				imgs[i] = Views.subsample(img, 2*i, 2*i, 2*i, 1);
+		}
+
+		final RandomAccessibleIntervalMipmapSource4D<DoubleType> raiSource4D = new RandomAccessibleIntervalMipmapSource4D<	>(
+				imgs,
+				Util.getTypeFromInterval(img),
+				transforms,
+				new FinalVoxelDimensions("um", 1, 1, 1 ),
+				"4d rai source", true );
+
+		final BdvStackSource<DoubleType> bdv = BdvFunctions.show( raiSource4D, 5 );
+		bdv.setDisplayRange(0, 3);
+	}
+}


### PR DESCRIPTION
@tpietzsch ,

@axtimwalde and I needed something like [RandomAccessibleIntervalSource4D](https://github.com/bigdataviewer/bigdataviewer-vistools/blob/master/src/main/java/bdv/util/RandomAccessibleIntervalSource4D.java) but with mipmaps. Such a source doesn't yet exist, so we made one here [RandomAccessibleIntervalMipmapSource4D](https://github.com/bigdataviewer/bigdataviewer-vistools/blob/more-4d/src/main/java/bdv/util/RandomAccessibleIntervalMipmapSource4D.java) (in the more-4d branch.

We also add an example using the new `RandomAccessibleIntervalMipmapSource4D`. As well, the dev branch of n5-viewer [uses it](https://github.com/saalfeldlab/n5-viewer/blob/6024aabd12f523faa8daa6f7ce0534f9494b26a1/src/main/java/org/janelia/saalfeldlab/n5/bdv/N5Viewer.java#L665), and [is tested](https://github.com/saalfeldlab/n5-viewer/blob/dev/src/test/java/org/janelia/saalfeldlab/n5/bdv/BdvMetadataIoTests.java#L94-L100), so I'm confident it works.

This also adds [VolatileSource](https://github.com/bigdataviewer/bigdataviewer-vistools/blob/more-4d/src/main/java/bdv/util/VolatileSource.java) which is just like the existing `VolatileRandomAccessibleIntervalMipmapSource`, but takes any Source as an argument rather than a `RandomAccessibleIntervalMipmapSource` [see the diff](https://github.com/bigdataviewer/bigdataviewer-vistools/commit/89e9bf02870d64f6424517a1ee1caf2413f9626f)