### PR TITLE
Fix bug when showing SpimData that doesn't have a ViewerImgLoader

### DIFF
--- a/src/main/java/bdv/util/BdvFunctions.java
+++ b/src/main/java/bdv/util/BdvFunctions.java
@@ -331,13 +331,15 @@ public class BdvFunctions
 			final BdvOptions options )
 	{
 		final BdvHandle handle = getHandle( options );
+		WrapBasicImgLoader.wrapImgLoaderIfNecessary( spimData );
+
 		final AbstractSequenceDescription< ?, ?, ? > seq = spimData.getSequenceDescription();
 		final int numTimepoints = seq.getTimePoints().size();
-		final VolatileGlobalCellCache cache = ( VolatileGlobalCellCache ) ( ( ViewerImgLoader ) seq.getImgLoader() ).getCacheControl();
+		final CacheControl cache = ( ( ViewerImgLoader ) seq.getImgLoader() ).getCacheControl();
 		handle.getBdvHandle().getCacheControls().addCacheControl( cache );
-		cache.clearCache();
+		if ( cache instanceof VolatileGlobalCellCache )
+			( ( VolatileGlobalCellCache ) cache ).clearCache();
 
-		WrapBasicImgLoader.wrapImgLoaderIfNecessary( spimData );
 		final ArrayList< SourceAndConverter< ? > > sources = new ArrayList<>();
 		BigDataViewer.initSetups( spimData, new ArrayList<>(), sources );
 


### PR DESCRIPTION
See discussion on zulip
https://imagesc.zulipchat.com/#narrow/stream/327326-BigDataViewer/topic/XML.20generated.20by.20BigStitcher.20not.20compatible.20with.20BDV.3F